### PR TITLE
Dockerfile: Install fedora packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ ARG cacert_url=undefined
 WORKDIR /src
 RUN dnf -y install \
     python3-gunicorn \
+    python3-flask \
     && dnf -y clean all \
     && rm -rf /tmp/*
 
@@ -21,7 +22,7 @@ RUN if [ "$cacert_url" != "undefined" ]; then \
 # This will allow a non-root user to install a custom root CA at run-time
 RUN chmod 777 /etc/pki/tls/certs/ca-bundle.crt
 COPY . .
-RUN pip3 install .
+RUN pip3 install . --no-deps
 USER 1001
 EXPOSE 8080
 ENTRYPOINT docker/install-ca.sh && gunicorn-3 --workers 8 --bind 0.0.0.0:8080 --access-logfile=- --enable-stdio-inheritance omps.app:app


### PR DESCRIPTION
Instead of installing dependencies via pip, use more stable fedora
RPMs.

Signed-off-by: Martin Bašti <mbasti@redhat.com>