### PR TITLE
Handle versions of operators manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ class ProdConfig:
     SECRET_KEY = "123456789secretkeyvalue"
     LOG_LEVEL = "INFO"
     LOG_FORMAT = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
-    DEFAULT_RELEASE_VERSION = "0.0.1"  # default operator manifest version
+    DEFAULT_RELEASE_VERSION = "1.0.0"  # default operator manifest version
 ```
 
 ## Running service
@@ -48,8 +48,10 @@ Zip file must be attached as `content_type='multipart/form-data'` assigned to
 field `file`. See `curl` examples bellow.
 
 If `<version>` is omitted:
-* the latest release version will be incremented and used [not implemented]
+* the latest release version will be incremented and used (for example from `2.5.1` to `3.0.0`)
 * for new repository a default initial version will be used (`DEFAULT_RELEASE_VERSION` config option)
+
+`<version>` must be unique for repository. Quay doesn't support overwriting of releases.
 
 #### Replies
 
@@ -86,6 +88,7 @@ Error messages have following format:
 |404| OMPSOrganizationNotFound | Requested organization is not configured on server side |
 |500| QuayLoginError | Server cannot login to quay, probably misconfiguration |
 |500| QuayCourierError | operator-courier module raised exception during building and pushing manifests to quay|
+|500| QuayPackageError | Failed to get information about application packages from quay |
 
 #### Example
 ```bash

--- a/omps/errors.py
+++ b/omps/errors.py
@@ -39,6 +39,21 @@ class QuayCourierError(OMPSError):
     code = 500
 
 
+class QuayPackageError(OMPSError):
+    """Error during getting package information from quay"""
+    code = 500
+
+
+class QuayPackageNotFound(OMPSError):
+    """Requested package doesn't exist"""
+    code = 404
+
+
+class OMPSInvalidVersionFormat(OMPSError):
+    """Invalid version format"""
+    code = 400
+
+
 def json_error(status, error, message):
     response = jsonify(
         {'status': status,

--- a/omps/quay.py
+++ b/omps/quay.py
@@ -42,6 +42,8 @@ class ReleaseVersion:
                     version, msg
                 ))
 
+        assert isinstance(version, str)
+
         parts = version.split('.')
         if len(parts) != 3:
             _raise("version must consist of 3 parts separated by '.'")
@@ -95,6 +97,11 @@ class ReleaseVersion:
 
     def __str__(self):
         return '{}.{}.{}'.format(self._x, self._y, self._z)
+
+    def __repr__(self):
+        return "{}({}, {}, {})".format(
+            self.__class__.__name__, self._x, self._y, self._z
+        )
 
     def increment(self):
         """Increments the most significant part of version by 1, zeroing

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@
 #
 
 from collections import namedtuple
+import re
 import os
 import shutil
 import zipfile
@@ -14,6 +15,8 @@ import pytest
 import requests_mock
 
 from omps.app import app
+from omps.errors import QuayPackageNotFound
+from omps.quay import QuayOrganization
 
 
 
@@ -77,12 +80,16 @@ def endpoint_push_zipfile(request):
 
 
 @pytest.fixture
-def mocked_quay_login():
-    """Returns JSON with token"""
+def mocked_quay_io():
+    """Mocking quay.io answers"""
     with requests_mock.Mocker() as m:
         m.post(
-            'https://quay.io/cnr/api/v1/users/login',
+            '/cnr/api/v1/users/login',
             json={'token': 'faketoken'}
+        )
+        m.get(
+            re.compile(r'/cnr/api/v1/packages/.*'),
+            status_code=404,
         )
         yield m
 

--- a/tests/push/test_api.py
+++ b/tests/push/test_api.py
@@ -12,7 +12,7 @@ from omps import constants
 
 def test_push_zipfile(
         client, valid_manifests_archive, endpoint_push_zipfile,
-        mocked_quay_login, mocked_op_courier_push):
+        mocked_quay_io, mocked_op_courier_push):
     """Test REST API for pushing operators form zipfile"""
     with open(valid_manifests_archive, 'rb') as f:
         data = {
@@ -28,7 +28,6 @@ def test_push_zipfile(
     expected = {
         'organization': endpoint_push_zipfile.org,
         'repo': endpoint_push_zipfile.repo,
-        'msg': 'Not Implemented. Testing only',
         'version': endpoint_push_zipfile.version or constants.DEFAULT_RELEASE_VERSION,
         'extracted_files': ['empty.yml'],
     }
@@ -41,7 +40,7 @@ def test_push_zipfile(
 ))
 def test_push_zipfile_invalid_file(
         client, filename, endpoint_push_zipfile,
-        mocked_quay_login):
+        mocked_quay_io):
     """Test if proper error is returned when no zip file is being attached"""
     data = {
         'file': (BytesIO(b'randombytes'), filename),
@@ -58,7 +57,7 @@ def test_push_zipfile_invalid_file(
     assert rv_json['error'] == 'OMPSUploadedFileError'
 
 
-def test_push_zipfile_no_file(client, endpoint_push_zipfile, mocked_quay_login):
+def test_push_zipfile_no_file(client, endpoint_push_zipfile, mocked_quay_io):
     """Test if proper error is returned when no file is being attached"""
     rv = client.post(endpoint_push_zipfile.url_path)
     assert rv.status_code == 400, rv.get_json()

--- a/tests/test_quay.py
+++ b/tests/test_quay.py
@@ -15,7 +15,7 @@ from omps.settings import TestConfig, Config
 class TestQuayOrganizationManager:
     """Tests for QuayOrganizationManager class"""
 
-    def test_organization_login(self, mocked_quay_login):
+    def test_organization_login(self, mocked_quay_io):
         """Test successful org login"""
         qom = QuayOrganizationManager()
         conf = Config(TestConfig)
@@ -24,7 +24,7 @@ class TestQuayOrganizationManager:
         org = qom.organization_login('testorg')
         assert isinstance(org, QuayOrganization)
 
-    def test_organization_login_org_not_found(self, mocked_quay_login):
+    def test_organization_login_org_not_found(self, mocked_quay_io):
         """Test login to not configured org"""
         qom = QuayOrganizationManager()
         conf = Config(TestConfig)


### PR DESCRIPTION
* validate user specified version to use format '<int>.<int>.<int>'
* if version is specified by user, use that version, otherwise:
  * if a new operator manifest is pushed use default version 1.0.0
  * if the operator manifest already exist, new version will be derived from the latest
    version by incrementing by 1 at the most significant part (1.0.2 -->
    2.0.0)

* OSBS-6688

Signed-off-by: Martin Bašti <mbasti@redhat.com>

**TODO**

- [x] extend tests
- [x] documentation