### PR TITLE
Measure coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,6 @@ matrix:
       python: "3.6"
     - dist: xenial
       python: "3.7"
-install: pip install tox-travis
+install: pip install tox-travis coveralls
 script: tox
+after_success: coveralls

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 # Operators Manifests Push Service (OMPS)
+
+[![Build Status](https://travis-ci.com/release-engineering/operators-manifests-push-service.svg?branch=master)](https://travis-ci.com/release-engineering/operators-manifests-push-service)
+[![Coverage Status](https://coveralls.io/repos/github/release-engineering/operators-manifests-push-service/badge.svg?branch=master)](https://coveralls.io/github/release-engineering/operators-manifests-push-service?branch=master)
+
 Service for pushing operators manifests to quay.io from various sources.
 
 ## Settings

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
     extras_require={
         'test': [
             'pytest',
+            'pytest-cov',
             'requests-mock',
             'flexmock',
         ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,9 @@
 [tox]
 envlist = py36,py37
 
-
 [testenv]
 deps = .[test]
+commands = pytest --cov=omps tests/
 
-commands = py.test tests/
+[coverage:report]
+fail_under = 87


### PR DESCRIPTION
Enable measuring code coverage, and publish the results to Coveralls.

Fail the unit tests, if coverage drops bellow the current level.

`tests/__init__.py` had to be added, otherwise no code coverage data
was collected (some strange behaviour of pytest-cov or some underlying
library).

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>