### PR TITLE
Dockerfile: use python3-operator-courier instead RPM link

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN dnf -y install \
     python3-flask \
     python3-jsonschema \
     python3-requests \
-    https://kojipkgs.fedoraproject.org//packages/python-operator-courier/1.0.0/1.fc29/noarch/python3-operator-courier-1.0.0-1.fc29.noarch.rpm \
+    python3-operator-courier \
     && dnf -y clean all \
     && rm -rf /tmp/*
 


### PR DESCRIPTION
operator-courier is now part of fedora stable repos

Signed-off-by: Martin Bašti <mbasti@redhat.com>