### PR TITLE
Auth: use quay.io tokens for auth

### DIFF
--- a/omps/api/common.py
+++ b/omps/api/common.py
@@ -1,0 +1,23 @@
+#
+# Copyright (C) 2019 Red Hat, Inc
+# see the LICENSE file for license
+#
+
+""" Defines shared functions for API """
+
+from omps.errors import OMPSAuthorizationHeaderRequired
+
+
+def extract_auth_token(req):
+    """Extracts auth token from request header
+
+    :param req: Flask request
+    :rtype: str
+    :return: Auth token
+    """
+    auth_header = req.headers.get('Authorization', None)
+    if auth_header is None:
+        raise OMPSAuthorizationHeaderRequired(
+            "Request contains no 'Authorization' header")
+
+    return auth_header

--- a/omps/api/v1/packages.py
+++ b/omps/api/v1/packages.py
@@ -4,11 +4,12 @@
 #
 import logging
 
-from flask import jsonify
+from flask import jsonify, request
 import requests
 
 from . import API
-from omps.quay import QUAY_ORG_MANAGER
+from omps.api.common import extract_auth_token
+from omps.quay import QuayOrganization
 
 logger = logging.getLogger(__name__)
 
@@ -25,7 +26,8 @@ def delete_package_release(organization, repo, version=None):
     :param version: version of operator manifest
     :return: HTTP response
     """
-    quay_org = QUAY_ORG_MANAGER.organization_login(organization)
+    token = extract_auth_token(request)
+    quay_org = QuayOrganization(organization, token)
 
     # quay.io may contain OMPS incompatible release version format string
     # but we want to be able to delete everything there, thus using _raw

--- a/omps/api/v1/push.py
+++ b/omps/api/v1/push.py
@@ -10,6 +10,7 @@ import zipfile
 from flask import jsonify, current_app, request
 
 from . import API
+from omps.api.common import extract_auth_token
 from omps.constants import (
     ALLOWED_EXTENSIONS,
     DEFAULT_ZIPFILE_MAX_UNCOMPRESSED_SIZE,
@@ -20,7 +21,7 @@ from omps.errors import (
     OMPSExpectedFileError,
     QuayPackageNotFound,
 )
-from omps.quay import QUAY_ORG_MANAGER, ReleaseVersion
+from omps.quay import QuayOrganization, ReleaseVersion
 
 logger = logging.getLogger(__name__)
 
@@ -121,7 +122,8 @@ def push_zipfile(organization, repo, version=None):
     :param repo: target repository
     :param version: version of operator manifest
     """
-    quay_org = QUAY_ORG_MANAGER.organization_login(organization)
+    token = extract_auth_token(request)
+    quay_org = QuayOrganization(organization, token)
 
     version = _get_package_version(quay_org, repo, version)
     logger.info("Using release version: %s", version)

--- a/omps/app.py
+++ b/omps/app.py
@@ -11,7 +11,6 @@ from .api.v1 import API as API_V1
 from .errors import init_errors_handling
 from .logger import init_logging
 from .settings import init_config
-from .quay import QUAY_ORG_MANAGER
 
 
 logger = logging.getLogger(__name__)
@@ -32,7 +31,6 @@ def _load_config(app):
     conf = init_config(app)
     init_logging(conf)
     logger.debug('Config loaded. Logging initialized')
-    QUAY_ORG_MANAGER.init_from_config(conf)
 
 
 def _init_errors_handling(app):

--- a/omps/errors.py
+++ b/omps/errors.py
@@ -24,16 +24,6 @@ class OMPSExpectedFileError(OMPSError):
     code = 400
 
 
-class OMPSOrganizationNotFound(OMPSError):
-    """Requested organization cannot be accessed"""
-    code = 404
-
-
-class QuayLoginError(OMPSError):
-    """Login to quay.io failed"""
-    code = 500
-
-
 class QuayCourierError(OMPSError):
     """Operator-courier library failures"""
     code = 500
@@ -52,6 +42,11 @@ class QuayPackageNotFound(OMPSError):
 class OMPSInvalidVersionFormat(OMPSError):
     """Invalid version format"""
     code = 400
+
+
+class OMPSAuthorizationHeaderRequired(OMPSError):
+    """Request doesn't contain 'Authorization' header"""
+    code = 403
 
 
 def json_error(status, error, message):

--- a/omps/quay.py
+++ b/omps/quay.py
@@ -9,13 +9,10 @@ import re
 from functools import total_ordering
 import logging
 
-import jsonschema
 import requests
 from operatorcourier import api as courier_api
 
 from .errors import (
-    QuayLoginError,
-    OMPSOrganizationNotFound,
     QuayCourierError,
     QuayPackageNotFound,
     QuayPackageError,
@@ -104,98 +101,6 @@ class ReleaseVersion:
         self._x += 1
         self._y = 0
         self._z = 0
-
-
-class QuayOrganizationManager:
-    """Class responsible for handling configured organizations"""
-
-    SCHEMA_ORGANIZATIONS = {
-        "$schema": "http://json-schema.org/draft-04/schema#",
-        "title": "Configuration for accessing Quay.io organizations",
-        "type": ["object"],
-        "patternProperties": {
-            "^[a-zA-Z0-9_][a-zA-Z0-9_.-]{0,127}": {
-                "description": "Organization name",
-                "type": "object",
-                "properties": {
-                    "username": {
-                        "description": "quay.io username",
-                        "type": "string",
-                    },
-                    "password": {
-                        "description": "quay.io password",
-                        "type": "string",
-                    },
-                },
-                "required": ['username', 'password'],
-            },
-        },
-        "uniqueItems": True,
-        "additionalProperties": False,
-    }
-
-    @classmethod
-    def validate_config(cls, organizations):
-        """Validate quay organizations configuration
-
-        :param organizations: dictionary with configuration
-        :raises jsonschema.ValidationError: when configuration doesn't meet
-            expectations
-        """
-        jsonschema.validate(organizations, cls.SCHEMA_ORGANIZATIONS)
-
-    def __init__(self):
-        self._organizations = {}
-        self._quay_url = "https://quay.io"
-
-    def init_from_config(self, config):
-        """Initialize object from config"""
-        self.validate_config(config.quay_organizations)
-        self._organizations = config.quay_organizations
-        if not self._organizations:
-            logger.error('No organizations configured')
-
-    def _login(self, username, password):
-        endpoint = '/cnr/api/v1/users/login'
-        data = {
-            "user": {
-                "username": username,
-                "password": password,
-            },
-        }
-        url = self._quay_url + endpoint
-        r = requests.post(url, json=data)
-
-        if r.status_code != requests.codes.ok:
-            details = 'unknown details'
-            try:
-                details = r.json()['error']
-            except Exception:
-                pass
-            msg = 'Failed to login: {} ({})'.format(r.status_code, details)
-            logger.error(msg)
-            raise QuayLoginError(msg)
-
-        content = r.json()
-        if 'token' not in content:
-            raise QuayLoginError("Answer from quay doesn't contain token")
-        return content['token']
-
-    def organization_login(self, organization):
-        """Login to organization and return QuayOrganization object
-
-        :param organization: organization name
-        :return: QuayOrganization object
-        """
-        org_config = self._organizations.get(organization)
-        if org_config is None:
-            raise OMPSOrganizationNotFound(
-                "Organization '{}' not found in configuration".format(
-                    organization
-                )
-            )
-        token = self._login(org_config['username'], org_config['password'])
-        return QuayOrganization(organization, token)
 
 
 class QuayOrganization:
@@ -352,6 +257,3 @@ class QuayOrganization:
 
             logger.error("Delete release (%s): %s", r.status_code, msg)
             raise QuayPackageError(msg)
-
-
-QUAY_ORG_MANAGER = QuayOrganizationManager()

--- a/omps/settings.py
+++ b/omps/settings.py
@@ -7,10 +7,7 @@ import imp
 import os
 import sys
 
-import jsonschema
-
 from . import constants
-from .quay import QuayOrganizationManager
 
 
 class DefaultConfig:
@@ -32,12 +29,6 @@ class DevConfig(DefaultConfig):
 
 class TestConfig(DefaultConfig):
     TESTING = True
-    QUAY_ORGANIZATIONS = {
-        "testorg": {
-            "username": "testuser",
-            "password": "test_passwd",
-        }
-    }
 
 
 def init_config(app):
@@ -109,11 +100,6 @@ class Config(object):
             'default': constants.DEFAULT_RELEASE_VERSION,
             'desc': 'Default release version for new operator manifests releases'
         },
-        'quay_organizations': {
-            'type': dict,
-            'default': {},
-            'desc': 'Configuration of quay organizations'
-        }
     }
 
     def __init__(self, conf_section_obj):
@@ -222,10 +208,3 @@ class Config(object):
             raise ValueError(
                 "default_release_version must be in format 'x.y.z'")
         self._default_release_version = s
-
-    def _setifok_quay_organizations(self, s):
-        try:
-            QuayOrganizationManager.validate_config(s)
-        except jsonschema.ValidationError as e:
-            raise ValueError("config quay_organizations: {}".format(e))
-        self._quay_organizations = s

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,6 @@ setup(
     python_requires='>=3.6, <4',
     install_requires=[
         'Flask==1.0.*',
-        'jsonschema',
         'requests',
         'operator-courier',
     ],

--- a/tests/api/v1/conftest.py
+++ b/tests/api/v1/conftest.py
@@ -48,3 +48,8 @@ def endpoint_packages(request, release_version):
         url_path=url_path, org=organization,
         repo=repo, version=release_version
     )
+
+
+@pytest.fixture()
+def auth_header():
+    return {'Authorization': 'random_token'}

--- a/tests/api/v1/test_api_packages.py
+++ b/tests/api/v1/test_api_packages.py
@@ -26,6 +26,18 @@ def test_delete_released_package(
     assert rv.get_json() == expected
 
 
+def test_unauthorized(client, endpoint_packages):
+    """Test if api properly refuses unauthorized requests"""
+    rv = client.delete(
+        endpoint_packages.url_path,
+    )
+
+    assert rv.status_code == requests.codes.forbidden, rv.get_json()
+    rv_json = rv.get_json()
+    assert rv_json['status'] == requests.codes.forbidden
+    assert rv_json['error'] == 'OMPSAuthorizationHeaderRequired'
+
+
 @pytest.mark.parametrize('endpoint', [
     '/v1/organization-X/repo-Y',
     '/v1/organization-X/repo-Y/1.0.1',

--- a/tests/api/v1/test_api_packages.py
+++ b/tests/api/v1/test_api_packages.py
@@ -9,11 +9,12 @@ import requests
 
 def test_delete_released_package(
         client, valid_manifests_archive, endpoint_packages,
-        mocked_packages_delete_quay_io):
+        mocked_packages_delete_quay_io, auth_header):
     """Test REST API for deleting released operators manifest packages"""
 
     rv = client.delete(
         endpoint_packages.url_path,
+        headers=auth_header,
     )
 
     assert rv.status_code == requests.codes.ok, rv.get_json()

--- a/tests/api/v1/test_api_push.py
+++ b/tests/api/v1/test_api_push.py
@@ -12,7 +12,7 @@ from omps import constants
 
 def test_push_zipfile(
         client, valid_manifests_archive, endpoint_push_zipfile,
-        mocked_quay_io, mocked_op_courier_push):
+        mocked_quay_io, mocked_op_courier_push, auth_header):
     """Test REST API for pushing operators form zipfile"""
     with open(valid_manifests_archive, 'rb') as f:
         data = {
@@ -20,6 +20,7 @@ def test_push_zipfile(
         }
         rv = client.post(
             endpoint_push_zipfile.url_path,
+            headers=auth_header,
             data=data,
             content_type='multipart/form-data',
         )
@@ -40,7 +41,7 @@ def test_push_zipfile(
 ))
 def test_push_zipfile_invalid_file(
         client, filename, endpoint_push_zipfile,
-        mocked_quay_io):
+        mocked_quay_io, auth_header):
     """Test if proper error is returned when no zip file is being attached"""
     data = {
         'file': (BytesIO(b'randombytes'), filename),
@@ -48,6 +49,7 @@ def test_push_zipfile_invalid_file(
     rv = client.post(
         endpoint_push_zipfile.url_path,
         data=data,
+        headers=auth_header,
         content_type='multipart/form-data',
     )
 
@@ -57,9 +59,10 @@ def test_push_zipfile_invalid_file(
     assert rv_json['error'] == 'OMPSUploadedFileError'
 
 
-def test_push_zipfile_no_file(client, endpoint_push_zipfile, mocked_quay_io):
+def test_push_zipfile_no_file(
+        client, endpoint_push_zipfile, mocked_quay_io, auth_header):
     """Test if proper error is returned when no file is being attached"""
-    rv = client.post(endpoint_push_zipfile.url_path)
+    rv = client.post(endpoint_push_zipfile.url_path, headers=auth_header)
     assert rv.status_code == 400, rv.get_json()
     rv_json = rv.get_json()
     assert rv_json['status'] == 400

--- a/tests/api/v1/test_api_push.py
+++ b/tests/api/v1/test_api_push.py
@@ -5,6 +5,7 @@
 
 from io import BytesIO
 
+import requests
 import pytest
 
 from omps import constants
@@ -67,6 +68,15 @@ def test_push_zipfile_no_file(
     rv_json = rv.get_json()
     assert rv_json['status'] == 400
     assert rv_json['error'] == 'OMPSExpectedFileError'
+
+
+def test_push_zipfile_unauthorized(client, endpoint_push_zipfile):
+    """Test if api properly refuses unauthorized requests"""
+    rv = client.post(endpoint_push_zipfile.url_path)
+    assert rv.status_code == requests.codes.forbidden, rv.get_json()
+    rv_json = rv.get_json()
+    assert rv_json['status'] == requests.codes.forbidden
+    assert rv_json['error'] == 'OMPSAuthorizationHeaderRequired'
 
 
 def test_push_koji_nvr(client):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,10 +62,6 @@ def valid_manifests_archive(datadir, tmpdir):
 def mocked_quay_io():
     """Mocking quay.io answers"""
     with requests_mock.Mocker() as m:
-        m.post(
-            '/cnr/api/v1/users/login',
-            json={'token': 'faketoken'}
-        )
         m.get(
             re.compile(r'/cnr/api/v1/packages/.*'),
             status_code=404,
@@ -77,10 +73,6 @@ def mocked_quay_io():
 def mocked_packages_delete_quay_io(release_version):
     """Mocking quay.io answers for retrieving and deleting packages"""
     with requests_mock.Mocker() as m:
-        m.post(
-            '/cnr/api/v1/users/login',
-            json={'token': 'faketoken'}
-        )
         m.get(
             re.compile(r'/cnr/api/v1/packages/.*'),
             json=[
@@ -90,24 +82,6 @@ def mocked_packages_delete_quay_io(release_version):
         m.delete(
             re.compile(r'/cnr/api/v1/packages/.*'),
             status_code=requests.codes.ok,
-        )
-        yield m
-
-
-@pytest.fixture
-def mocked_failed_quay_login():
-    """Returns HTTP 401 with error message"""
-    with requests_mock.Mocker() as m:
-        m.post(
-            'https://quay.io/cnr/api/v1/users/login',
-            json={
-                "error": {
-                    "code": "unauthorized-access",
-                    "details": {},
-                    "message": "Invalid Username or Password"
-                }
-            },
-            status_code=401,
         )
         yield m
 

--- a/tests/test_quay.py
+++ b/tests/test_quay.py
@@ -9,13 +9,13 @@ import requests_mock
 import pytest
 
 from omps.errors import (
-    OMPSOrganizationNotFound,
     QuayPackageError,
     QuayPackageNotFound,
-    QuayLoginError
 )
-from omps.quay import QuayOrganizationManager, QuayOrganization, ReleaseVersion
-from omps.settings import TestConfig, Config
+from omps.quay import QuayOrganization, ReleaseVersion
+
+
+TOKEN = "basic randomtoken"
 
 
 class TestReleaseVersion:
@@ -88,36 +88,6 @@ class TestReleaseVersion:
         version = ReleaseVersion.from_str("1.0.0")
         with pytest.raises(TypeError):
             assert version < value
-
-
-class TestQuayOrganizationManager:
-    """Tests for QuayOrganizationManager class"""
-
-    def test_organization_login(self, mocked_quay_io):
-        """Test successful org login"""
-        qom = QuayOrganizationManager()
-        conf = Config(TestConfig)
-        qom.init_from_config(conf)
-
-        org = qom.organization_login('testorg')
-        assert isinstance(org, QuayOrganization)
-
-    def test_organization_login_org_not_found(self, mocked_quay_io):
-        """Test login to not configured org"""
-        qom = QuayOrganizationManager()
-        conf = Config(TestConfig)
-        qom.init_from_config(conf)
-        with pytest.raises(OMPSOrganizationNotFound):
-            qom.organization_login('org_not_configured')
-
-    def test_organization_login_failed(self, mocked_failed_quay_login):
-        """Test login with invalid credentials"""
-        qom = QuayOrganizationManager()
-        # credentials are valid here, failure is mocked
-        conf = Config(TestConfig)
-        qom.init_from_config(conf)
-        with pytest.raises(QuayLoginError):
-            qom.organization_login('testorg')
 
 
 class TestQuayOrganization:
@@ -216,7 +186,7 @@ class TestQuayOrganization:
         org = "test_org"
         repo = "test_repo"
 
-        qo = QuayOrganization(org, "token")
+        qo = QuayOrganization(org, TOKEN)
         (flexmock(qo)
          .should_receive('get_releases_raw')
          .and_return(["1.0.0", "1.0.1-random", "1.2.0"])
@@ -232,7 +202,7 @@ class TestQuayOrganization:
         repo = "test_repo"
         version = '1.2.3'
 
-        qo = QuayOrganization(org, "token")
+        qo = QuayOrganization(org, TOKEN)
 
         with requests_mock.Mocker() as m:
             m.delete(
@@ -252,7 +222,7 @@ class TestQuayOrganization:
         repo = "test_repo"
         version = '1.2.3'
 
-        qo = QuayOrganization(org, "token")
+        qo = QuayOrganization(org, TOKEN)
 
         with requests_mock.Mocker() as m:
             m.delete(

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -26,7 +26,6 @@ from omps.settings import Config, DefaultConfig
         "DEFAULT_RELEASE_VERSION",
         constants.DEFAULT_RELEASE_VERSION,
     ),
-    ("QUAY_ORGANIZATIONS", {}),
 ))
 def test_defaults(key, expected):
     """Test if defaults are properly propagated to app config"""
@@ -94,38 +93,6 @@ def test_zipfile_max_uncompressed_size_invalid():
 
     class ConfClass(DefaultConfig):
         ZIPFILE_MAX_UNCOMPRESSED_SIZE = -10
-
-    with pytest.raises(ValueError):
-        Config(ConfClass)
-
-
-def test_quay_organizations():
-    """Test of setting quay_organizations"""
-    expected = {
-        "testorg": {
-            "username": "testuser",
-            "password": "testpwd",
-        }
-    }
-
-    class ConfClass(DefaultConfig):
-        QUAY_ORGANIZATIONS = expected
-
-    conf = Config(ConfClass)
-    assert conf._quay_organizations == expected
-
-
-@pytest.mark.parametrize('org_conf', [
-    {'org': 'string'},
-    {'-wrong/org': {'username': 'u', 'password': 'p'}},
-    {'org': {'username': 'missing password'}},
-    {'org': {'password': 'missing username'}},
-    {'org': {'username': True, 'password': 'p'}},
-])
-def test_quay_organizations_invalid(org_conf):
-    """Test invalid quay_organizations config"""
-    class ConfClass(DefaultConfig):
-        QUAY_ORGANIZATIONS = org_conf
 
     with pytest.raises(ValueError):
         Config(ConfClass)


### PR DESCRIPTION
TODO: 

- [ ] README update
- [x] Extend tests for unauthorized access

Users are supposed to use 'Authorization' header with token given by
quay.io login endpoint.

OMPS will pass this token to quay.io.
OMPS won't keep any secrets, all control management happens at quay.io
side.

Note: for security reasons, only robot accounts should be used for login
to get token.

Signed-off-by: Martin Bašti <mbasti@redhat.com>