### PR TITLE
Integration tests for authorization

### DIFF
--- a/tests/integration/authorization/authorization_test.py
+++ b/tests/integration/authorization/authorization_test.py
@@ -1,0 +1,45 @@
+#
+# Copyright (C) 2019 Red Hat, Inc
+# see the LICENSE file for license
+#
+
+import os
+import shutil
+import pytest
+import requests
+from tests.integration.utils import OMPS
+
+
+@pytest.fixture(scope='module')
+def no_auth_omps():
+    api_url = os.getenv('OMPS_INT_TEST_OMPS_URL')
+    organization = os.getenv('OMPS_INT_TEST_OMPS_ORG')
+
+    return OMPS(api_url, organization)
+
+
+def test_upload_without_authorization(no_auth_omps, tmp_path):
+    """
+    Upload fails, when no 'Authorization' header is provided.
+    """
+    archive = shutil.make_archive(tmp_path / 'archive', 'zip',
+                                  'tests/integration/push_archive/artifacts/')
+    response = no_auth_omps.upload(repo='int-test', archive=archive)
+
+    assert response.status_code == requests.codes.forbidden
+    assert response.json()['error'] == 'OMPSAuthorizationHeaderRequired'
+
+
+def test_delete_without_authorization(no_auth_omps, omps, quay, tmp_path):
+    """
+    Deleting a version fails, when no 'Authorization' header is provided.
+    """
+    archive = shutil.make_archive(tmp_path / 'archive', 'zip',
+                                  'tests/integration/push_archive/artifacts/')
+    response = omps.upload(repo='int-test', archive=archive).raise_for_status()
+    assert quay.get_release(omps.organization, 'int-test', '1.0.0')
+
+    response = no_auth_omps.delete(no_auth_omps.organization, 'int-test', '1.0.0')
+
+    assert response.status_code == requests.codes.forbidden
+    assert response.json()['error'] == 'OMPSAuthorizationHeaderRequired'

--- a/tests/integration/authorization/authorization_test.py
+++ b/tests/integration/authorization/authorization_test.py
@@ -8,6 +8,7 @@ import shutil
 import pytest
 import requests
 from tests.integration.utils import OMPS
+from tests.integration.constants import TEST_PACKAGE
 
 
 @pytest.fixture(scope='module')
@@ -24,7 +25,7 @@ def test_upload_without_authorization(no_auth_omps, tmp_path):
     """
     archive = shutil.make_archive(tmp_path / 'archive', 'zip',
                                   'tests/integration/push_archive/artifacts/')
-    response = no_auth_omps.upload(repo='int-test', archive=archive)
+    response = no_auth_omps.upload(repo=TEST_PACKAGE, archive=archive)
 
     assert response.status_code == requests.codes.forbidden
     assert response.json()['error'] == 'OMPSAuthorizationHeaderRequired'
@@ -36,10 +37,10 @@ def test_delete_without_authorization(no_auth_omps, omps, quay, tmp_path):
     """
     archive = shutil.make_archive(tmp_path / 'archive', 'zip',
                                   'tests/integration/push_archive/artifacts/')
-    response = omps.upload(repo='int-test', archive=archive).raise_for_status()
-    assert quay.get_release(omps.organization, 'int-test', '1.0.0')
+    response = omps.upload(repo=TEST_PACKAGE, archive=archive).raise_for_status()
+    assert quay.get_release(omps.organization, TEST_PACKAGE, '1.0.0')
 
-    response = no_auth_omps.delete(no_auth_omps.organization, 'int-test', '1.0.0')
+    response = no_auth_omps.delete(no_auth_omps.organization, TEST_PACKAGE, '1.0.0')
 
     assert response.status_code == requests.codes.forbidden
     assert response.json()['error'] == 'OMPSAuthorizationHeaderRequired'

--- a/tests/integration/authorization/authorization_test.py
+++ b/tests/integration/authorization/authorization_test.py
@@ -8,15 +8,14 @@ import shutil
 import pytest
 import requests
 from tests.integration.utils import OMPS
-from tests.integration.constants import TEST_PACKAGE
+from tests.integration.constants import TEST_NAMESPACE, TEST_PACKAGE
 
 
 @pytest.fixture(scope='module')
 def no_auth_omps():
     api_url = os.getenv('OMPS_INT_TEST_OMPS_URL')
-    organization = os.getenv('OMPS_INT_TEST_OMPS_ORG')
 
-    return OMPS(api_url, organization)
+    return OMPS(api_url)
 
 
 def test_upload_without_authorization(no_auth_omps, tmp_path):
@@ -25,7 +24,8 @@ def test_upload_without_authorization(no_auth_omps, tmp_path):
     """
     archive = shutil.make_archive(tmp_path / 'archive', 'zip',
                                   'tests/integration/push_archive/artifacts/')
-    response = no_auth_omps.upload(repo=TEST_PACKAGE, archive=archive)
+    response = no_auth_omps.upload(organization=TEST_NAMESPACE,
+                                   repo=TEST_PACKAGE, archive=archive)
 
     assert response.status_code == requests.codes.forbidden
     assert response.json()['error'] == 'OMPSAuthorizationHeaderRequired'
@@ -37,10 +37,11 @@ def test_delete_without_authorization(no_auth_omps, omps, quay, tmp_path):
     """
     archive = shutil.make_archive(tmp_path / 'archive', 'zip',
                                   'tests/integration/push_archive/artifacts/')
-    response = omps.upload(repo=TEST_PACKAGE, archive=archive).raise_for_status()
-    assert quay.get_release(omps.organization, TEST_PACKAGE, '1.0.0')
+    response = omps.upload(organization=TEST_NAMESPACE,
+                           repo=TEST_PACKAGE, archive=archive).raise_for_status()
+    assert quay.get_release(TEST_NAMESPACE, TEST_PACKAGE, '1.0.0')
 
-    response = no_auth_omps.delete(no_auth_omps.organization, TEST_PACKAGE, '1.0.0')
+    response = no_auth_omps.delete(TEST_NAMESPACE, TEST_PACKAGE, '1.0.0')
 
     assert response.status_code == requests.codes.forbidden
     assert response.json()['error'] == 'OMPSAuthorizationHeaderRequired'

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -6,6 +6,7 @@
 import os
 import pytest
 from .utils import OMPS, QuayAppRegistry
+from .constants import TEST_PACKAGE
 
 
 @pytest.fixture(scope='session')
@@ -24,14 +25,16 @@ def quay():
     yield app_registry
 
     organization = os.getenv('OMPS_INT_TEST_OMPS_ORG')
-    app_registry.clean_up(organization, 'int-test')
+    app_registry.clean_up(organization, TEST_PACKAGE)
 
 
 @pytest.fixture(scope='session')
 def omps(quay):
     """OMPS used for testing.
 
-    Args: None.
+    Args:
+        quay: QuayAppRegistry object, for the Quay instance used by OMPS.
+
     Returns: An instance of OMPS.
     Raises: None.
     """

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -9,7 +9,7 @@ from .utils import OMPS, QuayAppRegistry
 
 
 @pytest.fixture(scope='session')
-def quay_app_registry():
+def quay():
     """Quay App Registry used for testing.
 
     Args: None.
@@ -28,7 +28,7 @@ def quay_app_registry():
 
 
 @pytest.fixture(scope='session')
-def omps(quay_app_registry):
+def omps(quay):
     """OMPS used for testing.
 
     Args: None.
@@ -38,4 +38,4 @@ def omps(quay_app_registry):
     api_url = os.getenv('OMPS_INT_TEST_OMPS_URL')
     organization = os.getenv('OMPS_INT_TEST_OMPS_ORG')
 
-    return OMPS(api_url, organization, quay_app_registry.token)
+    return OMPS(api_url, organization, quay.token)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -9,20 +9,6 @@ from .utils import OMPS, QuayAppRegistry
 
 
 @pytest.fixture(scope='session')
-def omps():
-    """OMPS used for testing.
-
-    Args: None.
-    Returns: An instance of OMPS.
-    Raises: None.
-    """
-    api_url = os.getenv('OMPS_INT_TEST_OMPS_URL')
-    organization = os.getenv('OMPS_INT_TEST_OMPS_ORG')
-
-    return OMPS(api_url, organization)
-
-
-@pytest.fixture(scope='session')
 def quay_app_registry():
     """Quay App Registry used for testing.
 
@@ -39,3 +25,17 @@ def quay_app_registry():
 
     organization = os.getenv('OMPS_INT_TEST_OMPS_ORG')
     app_registry.clean_up(organization, 'int-test')
+
+
+@pytest.fixture(scope='session')
+def omps(quay_app_registry):
+    """OMPS used for testing.
+
+    Args: None.
+    Returns: An instance of OMPS.
+    Raises: None.
+    """
+    api_url = os.getenv('OMPS_INT_TEST_OMPS_URL')
+    organization = os.getenv('OMPS_INT_TEST_OMPS_ORG')
+
+    return OMPS(api_url, organization, quay_app_registry.token)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -39,6 +39,5 @@ def omps(quay):
     Raises: None.
     """
     api_url = os.getenv('OMPS_INT_TEST_OMPS_URL')
-    organization = os.getenv('OMPS_INT_TEST_OMPS_ORG')
 
-    return OMPS(api_url, organization, quay.token)
+    return OMPS(api_url, quay.token)

--- a/tests/integration/constants.py
+++ b/tests/integration/constants.py
@@ -1,0 +1,10 @@
+#
+# Copyright (C) 2019 Red Hat, Inc
+# see the LICENSE file for license
+#
+
+import os
+
+
+TEST_NAMESPACE = os.getenv('OMPS_INT_TEST_OMPS_ORG')
+TEST_PACKAGE = os.getenv('OMPS_INT_TEST_PACKAGE', default='int-test')

--- a/tests/integration/delete_version/delete_version_test.py
+++ b/tests/integration/delete_version/delete_version_test.py
@@ -8,14 +8,14 @@ import requests
 import pytest
 
 
-def test_delete_version(omps, quay_app_registry, tmp_path):
+def test_delete_version(omps, quay, tmp_path):
     """
     When a version is requested to be deleted,
     and a release matching that version exists for the package,
     the matching release is deleted.
     """
     version = '10.9.8'
-    if not quay_app_registry.get_release(omps.organization, 'int-test', version):
+    if not quay.get_release(omps.organization, 'int-test', version):
         archive = shutil.make_archive(tmp_path / 'archive', 'zip',
                                       'tests/integration/push_archive/artifacts/')
         response = omps.upload(repo='int-test', version=version, archive=archive)
@@ -29,17 +29,17 @@ def test_delete_version(omps, quay_app_registry, tmp_path):
         'organization': omps.organization,
         'repo': 'int-test',
     }
-    assert not quay_app_registry.get_release(omps.organization, 'int-test', version)
+    assert not quay.get_release(omps.organization, 'int-test', version)
 
 
-def test_version_does_not_exist(omps, quay_app_registry, tmp_path):
+def test_version_does_not_exist(omps, quay, tmp_path):
     """
     If the version requested to be deleted, is not present in the package,
     a 'QuayPackageNotFound' error is returned.
     """
     # Ensure there is at least one more release besides the one to be deleted.
     version = '8.0.1'
-    if not quay_app_registry.get_release(omps.organization, 'int-test', version):
+    if not quay.get_release(omps.organization, 'int-test', version):
         archive = shutil.make_archive(tmp_path / 'archive', 'zip',
                                       'tests/integration/push_archive/artifacts/')
         response = omps.upload(repo='int-test', version=version, archive=archive)
@@ -47,8 +47,8 @@ def test_version_does_not_exist(omps, quay_app_registry, tmp_path):
 
     # Ensure the release to be deleted is not in the package.
     version = '10.9.8'
-    if quay_app_registry.get_release(omps.organization, 'int-test', version):
-        quay_app_registry.delete_releases(omps.organization + '/int-test', [version])
+    if quay.get_release(omps.organization, 'int-test', version):
+        quay.delete_releases(omps.organization + '/int-test', [version])
 
     response = omps.delete(omps.organization, 'int-test', version)
 
@@ -57,20 +57,20 @@ def test_version_does_not_exist(omps, quay_app_registry, tmp_path):
     assert "doesn't exist" in response.json()['message']
 
 
-def test_delete_all_versions(omps, quay_app_registry, tmp_path):
+def test_delete_all_versions(omps, quay, tmp_path):
     """
     When there is no version specified for the delete operation,
     all the releases of the package are deleted.
     """
     # Ensure there are at least 2 releases.
-    if len(quay_app_registry.get_releases(omps.organization, 'int-test')) < 2:
+    if len(quay.get_releases(omps.organization, 'int-test')) < 2:
         archive = shutil.make_archive(tmp_path / 'archive', 'zip',
                                       'tests/integration/push_archive/artifacts/')
         for version in ['8.0.0', '8.0.1']:
             response = omps.upload(repo='int-test', version=version, archive=archive)
 
     versions = [r['release'] for r in
-                quay_app_registry.get_releases(omps.organization, 'int-test')]
+                quay.get_releases(omps.organization, 'int-test')]
     assert len(versions) > 1
 
     response = omps.delete(omps.organization, 'int-test')
@@ -94,18 +94,18 @@ def test_organization_not_configured(omps):
     assert 'not found in configuration' in response.json()['message']
 
 
-def test_package_does_not_exist(omps, quay_app_registry):
+def test_package_does_not_exist(omps, quay):
     """
     Delete fails, if the package does not exist in Quay.
     """
     # Ensure package does not exist.
     package = 'no-such-package'
     name = '/'.join([omps.organization, package])
-    existing = [p['name'] for p in quay_app_registry.get_packages(omps.organization)]
+    existing = [p['name'] for p in quay.get_packages(omps.organization)]
     if name in existing:
         releases = [r['release'] for r in
-                    quay_app_registry.get_releases(omps.organization, 'no-such-package')]
-        quay_app_registry.delete_releases(name, releases)
+                    quay.get_releases(omps.organization, 'no-such-package')]
+        quay.delete_releases(name, releases)
 
     response = omps.delete(omps.organization, package)
 
@@ -118,7 +118,7 @@ def test_package_does_not_exist(omps, quay_app_registry):
     pytest.param('6.0.2', '5.0.0', id='highest version'),
     pytest.param('4.0.1', '7.0.0', id='previous version'),
 ])
-def test_increment_version_after_delete(omps, quay_app_registry, tmp_path,
+def test_increment_version_after_delete(omps, quay, tmp_path,
                                         delete_version, next_version):
     """
     Auto-incrementing the version works as expected,
@@ -128,11 +128,11 @@ def test_increment_version_after_delete(omps, quay_app_registry, tmp_path,
     """
     # Ensure only certain releases do exist.
     releases = set(r['release'] for r in
-                   quay_app_registry.get_releases(omps.organization, 'int-test'))
+                   quay.get_releases(omps.organization, 'int-test'))
     versions = set(['3.0.0', '4.0.1', '6.0.2'])
     to_delete = releases - versions
     to_upload = versions - releases
-    quay_app_registry.delete_releases(omps.organization + '/int-test', to_delete)
+    quay.delete_releases(omps.organization + '/int-test', to_delete)
     archive = shutil.make_archive(tmp_path / 'archive', 'zip',
                                   'tests/integration/push_archive/artifacts/')
     for version in to_upload:
@@ -148,4 +148,4 @@ def test_increment_version_after_delete(omps, quay_app_registry, tmp_path,
 
     assert response.status_code == requests.codes.ok
     assert response.json()['version'] == next_version
-    assert quay_app_registry.get_release(omps.organization, 'int-test', next_version)
+    assert quay.get_release(omps.organization, 'int-test', next_version)

--- a/tests/integration/delete_version/delete_version_test.py
+++ b/tests/integration/delete_version/delete_version_test.py
@@ -83,15 +83,15 @@ def test_delete_all_versions(omps, quay, tmp_path):
     }
 
 
-def test_organization_not_configured(omps):
+def test_organization_unaccessible_in_quay(omps):
     """
     Delete fails, if the organization is not configured with OMPS.
     """
     response = omps.delete('no-such-organization', 'int-test', '10.0.1')
 
-    assert response.status_code == requests.codes.not_found
-    assert response.json()['error'] == 'OMPSOrganizationNotFound'
-    assert 'not found in configuration' in response.json()['message']
+    assert response.status_code == requests.codes.internal_server_error
+    assert response.json()['error'] == 'QuayPackageError'
+    assert 'Unauthorized access' in response.json()['message']
 
 
 def test_package_does_not_exist(omps, quay):

--- a/tests/integration/delete_version/delete_version_test.py
+++ b/tests/integration/delete_version/delete_version_test.py
@@ -6,6 +6,7 @@
 import shutil
 import requests
 import pytest
+from tests.integration.constants import TEST_PACKAGE
 
 
 def test_delete_version(omps, quay, tmp_path):
@@ -15,21 +16,21 @@ def test_delete_version(omps, quay, tmp_path):
     the matching release is deleted.
     """
     version = '10.9.8'
-    if not quay.get_release(omps.organization, 'int-test', version):
+    if not quay.get_release(omps.organization, TEST_PACKAGE, version):
         archive = shutil.make_archive(tmp_path / 'archive', 'zip',
                                       'tests/integration/push_archive/artifacts/')
-        response = omps.upload(repo='int-test', version=version, archive=archive)
+        response = omps.upload(repo=TEST_PACKAGE, version=version, archive=archive)
         response.raise_for_status()
 
-    response = omps.delete(omps.organization, 'int-test', version)
+    response = omps.delete(omps.organization, TEST_PACKAGE, version)
 
     assert response.status_code == requests.codes.ok
     assert response.json() == {
         'deleted': [version],
         'organization': omps.organization,
-        'repo': 'int-test',
+        'repo': TEST_PACKAGE,
     }
-    assert not quay.get_release(omps.organization, 'int-test', version)
+    assert not quay.get_release(omps.organization, TEST_PACKAGE, version)
 
 
 def test_version_does_not_exist(omps, quay, tmp_path):
@@ -39,18 +40,18 @@ def test_version_does_not_exist(omps, quay, tmp_path):
     """
     # Ensure there is at least one more release besides the one to be deleted.
     version = '8.0.1'
-    if not quay.get_release(omps.organization, 'int-test', version):
+    if not quay.get_release(omps.organization, TEST_PACKAGE, version):
         archive = shutil.make_archive(tmp_path / 'archive', 'zip',
                                       'tests/integration/push_archive/artifacts/')
-        response = omps.upload(repo='int-test', version=version, archive=archive)
+        response = omps.upload(repo=TEST_PACKAGE, version=version, archive=archive)
         response.raise_for_status()
 
     # Ensure the release to be deleted is not in the package.
     version = '10.9.8'
-    if quay.get_release(omps.organization, 'int-test', version):
-        quay.delete_releases(omps.organization + '/int-test', [version])
+    if quay.get_release(omps.organization, TEST_PACKAGE, version):
+        quay.delete_releases('/'.join([omps.organization, TEST_PACKAGE]), [version])
 
-    response = omps.delete(omps.organization, 'int-test', version)
+    response = omps.delete(omps.organization, TEST_PACKAGE, version)
 
     assert response.status_code == requests.codes.not_found
     assert response.json()['error'] == 'QuayPackageNotFound'
@@ -63,23 +64,23 @@ def test_delete_all_versions(omps, quay, tmp_path):
     all the releases of the package are deleted.
     """
     # Ensure there are at least 2 releases.
-    if len(quay.get_releases(omps.organization, 'int-test')) < 2:
+    if len(quay.get_releases(omps.organization, TEST_PACKAGE)) < 2:
         archive = shutil.make_archive(tmp_path / 'archive', 'zip',
                                       'tests/integration/push_archive/artifacts/')
         for version in ['8.0.0', '8.0.1']:
-            response = omps.upload(repo='int-test', version=version, archive=archive)
+            response = omps.upload(repo=TEST_PACKAGE, version=version, archive=archive)
 
     versions = [r['release'] for r in
-                quay.get_releases(omps.organization, 'int-test')]
+                quay.get_releases(omps.organization, TEST_PACKAGE)]
     assert len(versions) > 1
 
-    response = omps.delete(omps.organization, 'int-test')
+    response = omps.delete(omps.organization, TEST_PACKAGE)
 
     assert response.status_code == requests.codes.ok
     assert response.json() == {
         'deleted': versions,
         'organization': omps.organization,
-        'repo': 'int-test',
+        'repo': TEST_PACKAGE,
     }
 
 
@@ -87,7 +88,7 @@ def test_organization_unaccessible_in_quay(omps):
     """
     Delete fails, if the organization is not configured with OMPS.
     """
-    response = omps.delete('no-such-organization', 'int-test', '10.0.1')
+    response = omps.delete('no-such-organization', TEST_PACKAGE, '10.0.1')
 
     assert response.status_code == requests.codes.internal_server_error
     assert response.json()['error'] == 'QuayPackageError'
@@ -128,24 +129,24 @@ def test_increment_version_after_delete(omps, quay, tmp_path,
     """
     # Ensure only certain releases do exist.
     releases = set(r['release'] for r in
-                   quay.get_releases(omps.organization, 'int-test'))
+                   quay.get_releases(omps.organization, TEST_PACKAGE))
     versions = set(['3.0.0', '4.0.1', '6.0.2'])
     to_delete = releases - versions
     to_upload = versions - releases
-    quay.delete_releases(omps.organization + '/int-test', to_delete)
+    quay.delete_releases('/'.join([omps.organization, TEST_PACKAGE]), to_delete)
     archive = shutil.make_archive(tmp_path / 'archive', 'zip',
                                   'tests/integration/push_archive/artifacts/')
     for version in to_upload:
-        response = omps.upload(repo='int-test', version=version, archive=archive)
+        response = omps.upload(repo=TEST_PACKAGE, version=version, archive=archive)
         response.raise_for_status()
 
     # Delete a release.
-    response = omps.delete(omps.organization, 'int-test', delete_version)
+    response = omps.delete(omps.organization, TEST_PACKAGE, delete_version)
     response.raise_for_status()
 
     # Push a new one, without specifying the version.
-    response = omps.upload(repo='int-test', archive=archive)
+    response = omps.upload(repo=TEST_PACKAGE, archive=archive)
 
     assert response.status_code == requests.codes.ok
     assert response.json()['version'] == next_version
-    assert quay.get_release(omps.organization, 'int-test', next_version)
+    assert quay.get_release(omps.organization, TEST_PACKAGE, next_version)

--- a/tests/integration/push_archive/push_archive_test.py
+++ b/tests/integration/push_archive/push_archive_test.py
@@ -167,7 +167,7 @@ def test_no_file_field(omps, tmp_path):
     assert 'No field "file"' in response.json()['message']
 
 
-def test_organization_not_configured(omps, tmp_path):
+def test_organization_unaccessible_in_quay(omps, tmp_path):
     """
     Push fails, if the organization is not configured in OMPS.
     """
@@ -177,9 +177,9 @@ def test_organization_not_configured(omps, tmp_path):
     response = omps.upload(repo='int-test', archive=archive,
                            organization=organization)
 
-    assert response.status_code == requests.codes.not_found
-    assert response.json()['error'] == 'OMPSOrganizationNotFound'
-    assert 'not found in configuration' in response.json()['message']
+    assert response.status_code == requests.codes.internal_server_error
+    assert response.json()['error'] == 'QuayPackageError'
+    assert 'Cannot retrieve information about package' in response.json()['message']
 
 
 def test_upload_password_protected_zip(omps):

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -15,11 +15,13 @@ class OMPS(object):
         _api_url: URL of the OMPS API. Including version, excluding trailing /.
         _organization: Organization configured in OMPS.
             This is the namespace to be used in the Quay App Registry.
+        _headers: Headers to be used, when talking to Quay.
+            No header will be set if None.
     """
-    def __init__(self, api_url, organization, quay_token):
+    def __init__(self, api_url, organization, quay_token=None):
         self._api_url = api_url
         self._organization = organization
-        self._auth = {'Authorization': quay_token}
+        self._headers = {'Authorization': quay_token} if quay_token else {}
 
     @property
     def organization(self):
@@ -51,7 +53,7 @@ class OMPS(object):
             version='' if not version else '/' + version)
         files = {field: open(archive, 'rb')}
 
-        return requests.post(url, files=files, headers=self._auth)
+        return requests.post(url, files=files, headers=self._headers)
 
     def delete(self, organization, repo, version=None):
         """Delete one, more or all releases from a repo.
@@ -73,7 +75,7 @@ class OMPS(object):
             repo=repo,
             version='' if not version else '/' + version)
 
-        return requests.delete(url, headers=self._auth)
+        return requests.delete(url, headers=self._headers)
 
 
 class QuayAppRegistry(object):

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -51,7 +51,7 @@ class OMPS(object):
             version='' if not version else '/' + version)
         files = {field: open(archive, 'rb')}
 
-        return requests.post(url, files=files)
+        return requests.post(url, files=files, headers=self._auth)
 
     def delete(self, organization, repo, version=None):
         """Delete one, more or all releases from a repo.
@@ -73,7 +73,7 @@ class OMPS(object):
             repo=repo,
             version='' if not version else '/' + version)
 
-        return requests.delete(url)
+        return requests.delete(url, headers=self._auth)
 
 
 class QuayAppRegistry(object):

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -13,30 +13,21 @@ class OMPS(object):
 
     Attributes:
         _api_url: URL of the OMPS API. Including version, excluding trailing /.
-        _organization: Organization configured in OMPS.
-            This is the namespace to be used in the Quay App Registry.
         _headers: Headers to be used, when talking to Quay.
             No header will be set if None.
     """
-    def __init__(self, api_url, organization, quay_token=None):
+    def __init__(self, api_url, quay_token=None):
         self._api_url = api_url
-        self._organization = organization
         self._headers = {'Authorization': quay_token} if quay_token else {}
 
-    @property
-    def organization(self):
-        """Organization configured in OMPS."""
-        return self._organization
-
-    def upload(self, repo, archive, organization=None, version=None,
+    def upload(self, organization, repo, archive, version=None,
                field='file'):
         """Create a new release for a package by uploading an archive.
 
         Args:
             repo: Repository where the new release is uploaded.
-            archive: Path of the archive to upload.
             organization: Name of the organization where the repo belongs.
-                If None, the organization configured in OMPS is used.
+            archive: Path of the archive to upload.
             version: Version to be used for this release.
                 If None, OMPS will create it.
 
@@ -48,7 +39,7 @@ class OMPS(object):
         """
         url = '{api}/{org}/{repo}/zipfile{version}'.format(
             api=self._api_url,
-            org=organization or self._organization,
+            org=organization,
             repo=repo,
             version='' if not version else '/' + version)
         files = {field: open(archive, 'rb')}

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -16,9 +16,10 @@ class OMPS(object):
         _organization: Organization configured in OMPS.
             This is the namespace to be used in the Quay App Registry.
     """
-    def __init__(self, api_url, organization):
+    def __init__(self, api_url, organization, quay_token):
         self._api_url = api_url
         self._organization = organization
+        self._auth = {'Authorization': quay_token}
 
     @property
     def organization(self):
@@ -95,13 +96,13 @@ class QuayAppRegistry(object):
         self._token = None
 
     def login(self, username, password):
-        """Login to Quay.
+        """Login to Quay and store token.
 
         Args:
             username, password: Credentials used to log in.
 
         Returns:
-            Authorization token.
+            None.
 
         Raises:
             HTTPError: Login failed.
@@ -118,6 +119,10 @@ class QuayAppRegistry(object):
         r.raise_for_status()
 
         self._token = r.json()['token']
+
+    @property
+    def token(self):
+        return self._token
 
     def get_releases(self, namespace, package):
         """Get all releases for a package.


### PR DESCRIPTION
Add integration tests to cover authorization, and adjust the integration test env and the other tests to match how OMPS works.