### PR TITLE
Integration tests for making repositories public

### DIFF
--- a/example.test.env.yaml
+++ b/example.test.env.yaml
@@ -1,8 +1,12 @@
 ---
 # Configuration example for the integration tests.
 
+# URL of the Quay App Registry API. No trailing '/'.
+quay_app_registry_api: https://quay.io/cnr/api/v1
 # URL of the Quay API. No trailing '/'.
-quay_url: https://quay.io/cnr/api/v1
+quay_api: https://quay.io/api/v1
+# OAuth token to be used for request going to quay_api
+quay_oauth_token: <quay application token>
 # User to authenticate with Quay.
 quay_user: <robot account>
 # Password to authenticate with Quay.

--- a/example.test.env.yaml
+++ b/example.test.env.yaml
@@ -26,3 +26,10 @@ koji_builds:
   valid_zip: valid-operator-container-1.0.0-1
   invalid_zip: invalid-operator-container-1.0.0-1
   not_an_operator: etcd-container-1.0.0-1
+# Configuration to test that an organization not configured
+# to be made public is kept private.
+private_org:
+  user: <robot account>
+  password: <robot token>
+  namespace: private-operators
+  package: integration-tests-private

--- a/tests/integration/authorization/authorization_test.py
+++ b/tests/integration/authorization/authorization_test.py
@@ -7,15 +7,15 @@
 import shutil
 import pytest
 import requests
-from tests.integration.utils import OMPS
+from tests.integration.utils import OMPS, test_env
 
 
 @pytest.fixture(scope='module')
-def no_auth_omps(test_env):
+def no_auth_omps():
     return OMPS(test_env['omps_url'])
 
 
-def test_upload_without_authorization(test_env, no_auth_omps, tmp_path):
+def test_upload_without_authorization(no_auth_omps, tmp_path):
     """
     Upload fails, when no 'Authorization' header is provided.
     """
@@ -28,7 +28,7 @@ def test_upload_without_authorization(test_env, no_auth_omps, tmp_path):
     assert response.json()['error'] == 'OMPSAuthorizationHeaderRequired'
 
 
-def test_delete_without_authorization(test_env, no_auth_omps, omps, quay, tmp_path):
+def test_delete_without_authorization(no_auth_omps, omps, quay, tmp_path):
     """
     Deleting a version fails, when no 'Authorization' header is provided.
     """

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -27,12 +27,14 @@ def quay(test_env):
     Yields: An instance of QuayAppRegistry.
     Raises: None.
     """
-    app_registry = QuayAppRegistry(test_env['quay_url'])
+    app_registry = QuayAppRegistry(test_env['quay_app_registry_api'],
+                                   test_env['quay_api'],
+                                   test_env['quay_oauth_token'])
     app_registry.login_to_cnr(test_env['quay_user'], test_env['quay_password'])
 
     yield app_registry
 
-    app_registry.clean_up(test_env['test_namespace'], test_env['test_package'])
+    app_registry.delete(test_env['test_namespace'], test_env['test_package'])
 
 
 @pytest.fixture(scope='session')

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -28,7 +28,7 @@ def quay(test_env):
     Raises: None.
     """
     app_registry = QuayAppRegistry(test_env['quay_url'])
-    app_registry.login(test_env['quay_user'], test_env['quay_password'])
+    app_registry.login_to_cnr(test_env['quay_user'], test_env['quay_password'])
 
     yield app_registry
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -4,21 +4,11 @@
 #
 
 import pytest
-import yaml
-from .utils import OMPS, QuayAppRegistry, Koji
+from .utils import OMPS, QuayAppRegistry, Koji, test_env
 
 
 @pytest.fixture(scope='session')
-def test_env():
-    """Test environment configuration.
-    """
-    with open('test.env.yaml') as f:
-        env = yaml.safe_load(f)
-    return env
-
-
-@pytest.fixture(scope='session')
-def quay(test_env):
+def quay():
     """Quay App Registry used for testing.
 
     Args:
@@ -38,7 +28,7 @@ def quay(test_env):
 
 
 @pytest.fixture(scope='session')
-def omps(test_env, quay):
+def omps(quay):
     """OMPS used for testing.
 
     Args:
@@ -52,7 +42,7 @@ def omps(test_env, quay):
 
 
 @pytest.fixture(scope='session')
-def koji(test_env):
+def koji():
     """Koji instance configured in OMPS.
 
     Args:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -52,3 +52,27 @@ def koji():
     Raises: None.
     """
     return Koji(test_env['kojihub'], test_env['kojiroot'])
+
+
+@pytest.fixture
+def private_quay():
+    quay = None
+
+    if test_env.get('private_org'):
+        quay = QuayAppRegistry(test_env['quay_app_registry_api'],
+                               test_env['quay_api'],
+                               test_env['quay_oauth_token'])
+        quay.login_to_cnr(test_env['private_org']['user'],
+                          test_env['private_org']['password'])
+
+    yield quay
+
+    if quay:
+        quay.delete(test_env['private_org']['namespace'],
+                    test_env['private_org']['package'])
+
+
+@pytest.fixture
+def private_omps(private_quay):
+    if private_quay:
+        return OMPS(test_env['omps_url'], private_quay.token)

--- a/tests/integration/delete_version/delete_version_test.py
+++ b/tests/integration/delete_version/delete_version_test.py
@@ -34,7 +34,9 @@ def test_delete_version(test_env, omps, quay, tmp_path):
         'repo': test_env['test_package'],
     }
     assert not quay.get_release(test_env['test_namespace'],
-                                test_env['test_package'], version)
+                                test_env['test_package'],
+                                version,
+                                authorization=None)
 
 
 def test_version_does_not_exist(test_env, omps, quay, tmp_path):
@@ -94,6 +96,10 @@ def test_delete_all_versions(test_env, omps, quay, tmp_path):
         'organization': test_env['test_namespace'],
         'repo': test_env['test_package'],
     }
+
+    assert not quay.get_releases(test_env['test_namespace'],
+                                 test_env['test_package'],
+                                 authorization=None)
 
 
 def test_organization_unaccessible_in_quay(test_env, omps):
@@ -167,4 +173,6 @@ def test_increment_version_after_delete(test_env, omps, quay, tmp_path,
     assert response.status_code == requests.codes.ok
     assert response.json()['version'] == next_version
     assert quay.get_release(test_env['test_namespace'],
-                            test_env['test_package'], next_version)
+                            test_env['test_package'],
+                            next_version,
+                            authorization=None)

--- a/tests/integration/delete_version/delete_version_test.py
+++ b/tests/integration/delete_version/delete_version_test.py
@@ -6,9 +6,10 @@
 import shutil
 import requests
 import pytest
+from tests.integration.utils import test_env
 
 
-def test_delete_version(test_env, omps, quay, tmp_path):
+def test_delete_version(omps, quay, tmp_path):
     """
     When a version is requested to be deleted,
     and a release matching that version exists for the package,
@@ -39,7 +40,7 @@ def test_delete_version(test_env, omps, quay, tmp_path):
                                 authorization=None)
 
 
-def test_version_does_not_exist(test_env, omps, quay, tmp_path):
+def test_version_does_not_exist(omps, quay, tmp_path):
     """
     If the version requested to be deleted, is not present in the package,
     a 'QuayPackageNotFound' error is returned.
@@ -70,7 +71,7 @@ def test_version_does_not_exist(test_env, omps, quay, tmp_path):
     assert "doesn't exist" in response.json()['message']
 
 
-def test_delete_all_versions(test_env, omps, quay, tmp_path):
+def test_delete_all_versions(omps, quay, tmp_path):
     """
     When there is no version specified for the delete operation,
     all the releases of the package are deleted.
@@ -102,7 +103,7 @@ def test_delete_all_versions(test_env, omps, quay, tmp_path):
                                  authorization=None)
 
 
-def test_organization_unaccessible_in_quay(test_env, omps):
+def test_organization_unaccessible_in_quay(omps):
     """
     Delete fails, if the organization is not configured with OMPS.
     """
@@ -113,7 +114,7 @@ def test_organization_unaccessible_in_quay(test_env, omps):
     assert 'Unauthorized access' in response.json()['message']
 
 
-def test_package_does_not_exist(test_env, omps, quay):
+def test_package_does_not_exist(omps, quay):
     """
     Delete fails, if the package does not exist in Quay.
     """
@@ -137,7 +138,7 @@ def test_package_does_not_exist(test_env, omps, quay):
     pytest.param('6.0.2', '5.0.0', id='highest version'),
     pytest.param('4.0.1', '7.0.0', id='previous version'),
 ])
-def test_increment_version_after_delete(test_env, omps, quay, tmp_path,
+def test_increment_version_after_delete(omps, quay, tmp_path,
                                         delete_version, next_version):
     """
     Auto-incrementing the version works as expected,

--- a/tests/integration/push_archive/push_archive_test.py
+++ b/tests/integration/push_archive/push_archive_test.py
@@ -6,9 +6,10 @@
 import shutil
 import pytest
 import requests
+from tests.integration.utils import test_env
 
 
-def test_initial_upload(test_env, omps, quay, tmp_path):
+def test_initial_upload(omps, quay, tmp_path):
     """
     When uploading an archive to a repository which is empty,
     and no version is specified during the upload
@@ -38,7 +39,7 @@ def test_initial_upload(test_env, omps, quay, tmp_path):
     assert releases[0]['release'] == '1.0.0'
 
 
-def test_upload_with_version(test_env, omps, quay, tmp_path):
+def test_upload_with_version(omps, quay, tmp_path):
     """
     When specifying the version for an upload,
     then the release is created with the version specified.
@@ -66,7 +67,7 @@ def test_upload_with_version(test_env, omps, quay, tmp_path):
                             authorization=None)
 
 
-def test_increment_version(test_env, omps, quay, tmp_path):
+def test_increment_version(omps, quay, tmp_path):
     """
     When no version is specified, and there already are some releases in
         the package,
@@ -103,7 +104,7 @@ def test_increment_version(test_env, omps, quay, tmp_path):
                             authorization=None)
 
 
-def test_version_exists(test_env, omps, quay, tmp_path):
+def test_version_exists(omps, quay, tmp_path):
     """
     When the version already exists in the package,
     then creating the new release fails.
@@ -134,7 +135,7 @@ def test_version_exists(test_env, omps, quay, tmp_path):
     ('1.a.2'),
     ('1.1'),
 ])
-def test_incorrect_version(test_env, omps, tmp_path, version):
+def test_incorrect_version(omps, tmp_path, version):
     """
     When the version specified does not meet OMPS requirements,
     then the push fails.
@@ -150,7 +151,7 @@ def test_incorrect_version(test_env, omps, tmp_path, version):
     assert version in response.json()['message']
 
 
-def test_filetype_not_supported(test_env, omps, tmpdir):
+def test_filetype_not_supported(omps, tmpdir):
     """
     If the file uploaded is not a ZIP file,
     then the push fails.
@@ -164,7 +165,7 @@ def test_filetype_not_supported(test_env, omps, tmpdir):
     assert 'not a zip file' in response.json()['message']
 
 
-def test_file_extension_not_zip(test_env, omps, tmpdir):
+def test_file_extension_not_zip(omps, tmpdir):
     """
     If the extension of the file is not '.zip',
     then the push fails.
@@ -178,7 +179,7 @@ def test_file_extension_not_zip(test_env, omps, tmpdir):
     assert 'file extension' in response.json()['message']
 
 
-def test_no_file_field(test_env, omps, tmp_path):
+def test_no_file_field(omps, tmp_path):
     """
     The ZIP file uploaded must be assigned to the 'file' field.
     """
@@ -193,7 +194,7 @@ def test_no_file_field(test_env, omps, tmp_path):
     assert 'No field "file"' in response.json()['message']
 
 
-def test_organization_unaccessible_in_quay(test_env, omps, tmp_path):
+def test_organization_unaccessible_in_quay(omps, tmp_path):
     """
     Push fails, if the organization is not configured in OMPS.
     """
@@ -208,7 +209,7 @@ def test_organization_unaccessible_in_quay(test_env, omps, tmp_path):
     assert 'Cannot retrieve information about package' in response.json()['message']
 
 
-def test_upload_password_protected_zip(test_env, omps):
+def test_upload_password_protected_zip(omps):
     """
     Push fails, if the ZIP-file is password-protected.
     """
@@ -221,7 +222,7 @@ def test_upload_password_protected_zip(test_env, omps):
     assert 'is encrypted' in response.json()['message']
 
 
-def test_upload_invalid_artifact(test_env, omps, tmp_path):
+def test_upload_invalid_artifact(omps, tmp_path):
     """
     Push fails, if the artifact does not pass quay-courier validation.
     """

--- a/tests/integration/push_archive/push_archive_test.py
+++ b/tests/integration/push_archive/push_archive_test.py
@@ -30,7 +30,9 @@ def test_initial_upload(test_env, omps, quay, tmp_path):
     assert response['repo'] == test_env['test_package']
     assert response['version'] == '1.0.0'
 
-    releases = quay.get_releases(test_env['test_namespace'], test_env['test_package'])
+    releases = quay.get_releases(test_env['test_namespace'],
+                                 test_env['test_package'],
+                                 authorization=None)
     assert releases
     assert len(releases) == 1
     assert releases[0]['release'] == '1.0.0'
@@ -58,7 +60,10 @@ def test_upload_with_version(test_env, omps, quay, tmp_path):
     assert response['repo'] == test_env['test_package']
     assert response['version'] == version
 
-    assert quay.get_release(test_env['test_namespace'], test_env['test_package'], version)
+    assert quay.get_release(test_env['test_namespace'],
+                            test_env['test_package'],
+                            version,
+                            authorization=None)
 
 
 def test_increment_version(test_env, omps, quay, tmp_path):
@@ -93,7 +98,9 @@ def test_increment_version(test_env, omps, quay, tmp_path):
     assert response['version'] == next_release
 
     assert quay.get_release(test_env['test_namespace'],
-                            test_env['test_package'], next_release)
+                            test_env['test_package'],
+                            next_release,
+                            authorization=None)
 
 
 def test_version_exists(test_env, omps, quay, tmp_path):

--- a/tests/integration/push_nvr/push_nvr_test.py
+++ b/tests/integration/push_nvr/push_nvr_test.py
@@ -63,7 +63,7 @@ def test_valid_zip_default_version(test_env, omps, quay, koji, tmp_path):
         from the Koji archive.
     """
     nvr = test_env['koji_builds']['valid_zip']
-    quay.clean_up_package(test_env['test_namespace'], test_env['test_package'])
+    quay.delete(test_env['test_namespace'], test_env['test_package'])
 
     response = omps.fetch_nvr(organization=test_env['test_namespace'],
                               repo=test_env['test_package'], nvr=nvr)
@@ -162,7 +162,7 @@ def test_increment_version(test_env, omps, quay, tmp_path):
     version = '7.6.1'
     next_version = '8.0.0'
 
-    quay.clean_up_package(test_env['test_namespace'], test_env['test_package'])
+    quay.delete(test_env['test_namespace'], test_env['test_package'])
     archive = shutil.make_archive(tmp_path / 'archive', 'zip',
                                   'tests/integration/push_archive/artifacts/')
     omps.upload(organization=test_env['test_namespace'],

--- a/tests/integration/push_nvr/push_nvr_test.py
+++ b/tests/integration/push_nvr/push_nvr_test.py
@@ -81,10 +81,12 @@ def test_valid_zip_default_version(test_env, omps, quay, koji, tmp_path):
         'version': '1.0.0',
     }
     assert quay.get_release(test_env['test_namespace'],
-                            test_env['test_package'], '1.0.0')
+                            test_env['test_package'], '1.0.0',
+                            authorization=None)
 
     quay_bundle = quay.get_bundle(test_env['test_namespace'],
-                                  test_env['test_package'], '1.0.0')
+                                  test_env['test_package'], '1.0.0',
+                                  authorization=None)
     koji.download_manifest(nvr, tmp_path)
     koji_bundle = courier.build_and_verify(source_dir=tmp_path.as_posix())
 
@@ -118,7 +120,8 @@ def test_valid_zip_defined_version(test_env, omps, quay):
         'version': version,
     }
     assert quay.get_release(test_env['test_namespace'],
-                            test_env['test_package'], version)
+                            test_env['test_package'], version,
+                            authorization=None)
 
 
 def test_version_exists(test_env, omps, quay, tmp_path):
@@ -181,4 +184,5 @@ def test_increment_version(test_env, omps, quay, tmp_path):
         'version': next_version,
     }
     assert quay.get_release(test_env['test_namespace'],
-                            test_env['test_package'], next_version)
+                            test_env['test_package'], next_version,
+                            authorization=None)

--- a/tests/integration/push_nvr/push_nvr_test.py
+++ b/tests/integration/push_nvr/push_nvr_test.py
@@ -6,9 +6,10 @@
 import shutil
 import requests
 from operatorcourier import api as courier
+from tests.integration.utils import test_env
 
 
-def test_invalid_zip(test_env, omps):
+def test_invalid_zip(omps):
     """
     When fetching an NVR from Koji,
     and the archive attached to the build has an invalid bundle,
@@ -23,7 +24,7 @@ def test_invalid_zip(test_env, omps):
     assert 'bundle is invalid' in response.json()['message']
 
 
-def test_not_an_operator(test_env, omps):
+def test_not_an_operator(omps):
     """
     When fetching an NVR from Koji,
     and the container image referenced by the NVR is not an operator,
@@ -38,7 +39,7 @@ def test_not_an_operator(test_env, omps):
     assert 'Not an operator image' in response.json()['message']
 
 
-def test_nvr_not_found(test_env, omps):
+def test_nvr_not_found(omps):
     """
     When fetching an NVR from Koji,
     and no build exists for that NVR in Koji,
@@ -53,7 +54,7 @@ def test_nvr_not_found(test_env, omps):
     assert 'NVR not found' in response.json()['message']
 
 
-def test_valid_zip_default_version(test_env, omps, quay, koji, tmp_path):
+def test_valid_zip_default_version(omps, quay, koji, tmp_path):
     """
     When fetching an NVR from Koji,
     and it's going to be the first release in the package,
@@ -95,7 +96,7 @@ def test_valid_zip_default_version(test_env, omps, quay, koji, tmp_path):
     assert quay_bundle == koji_bundle
 
 
-def test_valid_zip_defined_version(test_env, omps, quay):
+def test_valid_zip_defined_version(omps, quay):
     """
     When fetching an NVR from Koji,
     and there is a version specified,
@@ -124,7 +125,7 @@ def test_valid_zip_defined_version(test_env, omps, quay):
                             authorization=None)
 
 
-def test_version_exists(test_env, omps, quay, tmp_path):
+def test_version_exists(omps, quay, tmp_path):
     """
     When fetching an NVR from Koji,
     and the request specifies a version,
@@ -150,7 +151,7 @@ def test_version_exists(test_env, omps, quay, tmp_path):
     assert 'Failed to push' in response.json()['message']
 
 
-def test_increment_version(test_env, omps, quay, tmp_path):
+def test_increment_version(omps, quay, tmp_path):
     """
     When fetching an NVR from Koji,
     and the request specifies no version for the release to be created,

--- a/tests/integration/push_nvr/push_nvr_test.py
+++ b/tests/integration/push_nvr/push_nvr_test.py
@@ -5,6 +5,7 @@
 
 import shutil
 import requests
+import pytest
 from operatorcourier import api as courier
 from tests.integration.utils import test_env
 
@@ -187,3 +188,38 @@ def test_increment_version(omps, quay, tmp_path):
     assert quay.get_release(test_env['test_namespace'],
                             test_env['test_package'], next_version,
                             authorization=None)
+
+
+@pytest.mark.skipif(not test_env.get('private_org'),
+                    reason='No private organization configured.')
+def test_private_organization(private_omps, private_quay):
+    """
+    """
+    namespace = test_env['private_org']['namespace']
+    package = test_env['private_org']['package']
+    nvr = test_env['koji_builds']['valid_zip']
+    version = '1.0.0'
+    private_quay.delete(namespace, package)
+
+    response = private_omps.fetch_nvr(organization=namespace,
+                                      repo=package, nvr=nvr)
+
+    assert response.json() == {
+        'extracted_files': [
+            'crd.yaml',
+            'csv.yaml',
+            'packages.yaml'
+        ],
+        'nvr': nvr,
+        'organization': namespace,
+        'repo': package,
+        'version': version,
+    }
+    assert response.status_code == requests.codes.ok
+
+    assert private_quay.get_release(namespace, package, version)
+
+    with pytest.raises(requests.HTTPError) as err:
+        private_quay.get_release(namespace, package, version,
+                                 authorization=None)
+        assert '403' in str(err.value)

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -12,6 +12,17 @@ import zipfile
 from tempfile import TemporaryDirectory
 
 
+def load_test_env():
+    """Test environment configuration.
+    """
+    with open('test.env.yaml') as f:
+        env = yaml.safe_load(f)
+    return env
+
+
+test_env = load_test_env()
+
+
 class OMPS:
     """OMPS service.
 


### PR DESCRIPTION
This updates the integration tests to check changes in Quay without authorization, and also adds a test where the repo is not made public.