### PR TITLE
Allow fetch CA cert insecurely

### DIFF
--- a/docker/install-ca.sh
+++ b/docker/install-ca.sh
@@ -3,7 +3,7 @@ set -e
 
 if [ -n "${CA_URL}" ] && [ ! -f "/tmp/.imported" ]; then
     # Since update-ca-trust doesn't work as a non-root user, let's just append to the bundle directly
-    curl --silent --show-error "${CA_URL}" >> /etc/pki/tls/certs/ca-bundle.crt
+    curl --silent --show-error --insecure "${CA_URL}" >> /etc/pki/tls/certs/ca-bundle.crt
     # Create a file so we know not to import it again if the container is restarted
     touch /tmp/.imported
 fi


### PR DESCRIPTION
This workaround until a better solution is implemented to get CA
cert reliably.

Signed-off-by: Martin Bašti <mbasti@redhat.com>