### PR TITLE
Allow configuring a timeout for requests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,8 @@ LABEL \
 ARG cacert_url=undefined
 
 ENV WORKERS_NUM 8
+# Explicit worker timeout is 30 seconds.
+ENV WORKER_TIMEOUT 30
 
 WORKDIR /src
 RUN dnf -y install \
@@ -32,4 +34,4 @@ COPY . .
 RUN pip3 install . --no-deps
 USER 1001
 EXPOSE 8080
-ENTRYPOINT docker/install-ca.sh && gunicorn-3 --workers ${WORKERS_NUM} --bind 0.0.0.0:8080 --access-logfile=- --enable-stdio-inheritance omps.app:app
+ENTRYPOINT docker/install-ca.sh && gunicorn-3 --workers ${WORKERS_NUM} --timeout ${WORKER_TIMEOUT} --bind 0.0.0.0:8080 --access-logfile=- --enable-stdio-inheritance omps.app:app

--- a/omps/api/v1/health.py
+++ b/omps/api/v1/health.py
@@ -5,7 +5,7 @@
 
 import logging
 
-from flask import jsonify
+from flask import jsonify, current_app
 import requests
 from requests.exceptions import RequestException
 
@@ -41,7 +41,7 @@ def ping():
     # quay.io status
     try:
         # try to retrieve API version to check if quay.io is alive
-        get_cnr_api_version()
+        get_cnr_api_version(current_app.config['REQUEST_TIMEOUT'])
     except RequestException as e:
         logger.error('Quay version check: %s', e)
         quay_result = _err(e)

--- a/omps/koji_util.py
+++ b/omps/koji_util.py
@@ -26,7 +26,10 @@ class KojiUtil:
     def initialize(self, conf):
         self._kojihub_url = conf.kojihub_url
         self._kojiroot_url = conf.kojiroot_url
-        self._session = koji.ClientSession(self._kojihub_url)
+        opts = dict()
+        if conf.request_timeout is not None:
+            opts['timeout'] = conf.request_timeout
+        self._session = koji.ClientSession(self._kojihub_url, opts=opts)
 
         if not self._kojihub_url.endswith('/'):
             self._kojihub_url += '/'

--- a/omps/settings.py
+++ b/omps/settings.py
@@ -121,7 +121,12 @@ class Config(object):
             'type': dict,
             'default': {},
             'desc': 'Configuration of organizations'
-        }
+        },
+        'request_timeout': {
+            'type': int,
+            'default': None,
+            'desc': 'Timeout in seconds for Koji and Quay requests'
+        },
     }
 
     def __init__(self, conf_section_obj):

--- a/tests/test_quay.py
+++ b/tests/test_quay.py
@@ -504,4 +504,4 @@ class TestOrgManager:
 @pytest.mark.usefixtures('mocked_quay_version')
 def test_get_cnr_api_version():
     """Tests of quay.get_cnr_api_version function"""
-    assert get_cnr_api_version() == "0.0.1-test"
+    assert get_cnr_api_version(0) == "0.0.1-test"


### PR DESCRIPTION
1. Make the timout explicit for gunicorn workers in the Dockerfile.

2. Extend configuration with a 'REQUEST_TIMEOUT' option, which should be
considered both for Koji and Quay requests. For the later, the only
exception is the push operation, as Operator Courier API does not
have a timeout option yet.

All the above is done, so that the OMPS can be configured in a way,
where requests time out sooner than the workers. This way we hope to
catch some issues currently hidden by the worker timeouts.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>