### PR TITLE
Tell Operator Courier version in /about

### DIFF
--- a/docs/usage/v1.md
+++ b/docs/usage/v1.md
@@ -294,6 +294,7 @@ HTTP code: 200
 
 ```json
 {
+  "operatorcourier": "1.3.0",
   "version": "2.0"
 }
 ```

--- a/docs/usage/v2.md
+++ b/docs/usage/v2.md
@@ -299,6 +299,7 @@ HTTP code: 200
 
 ```json
 {
+  "operatorcourier": "1.3.0",
   "version": "2.0"
 }
 ```

--- a/omps/api/v1/about.py
+++ b/omps/api/v1/about.py
@@ -5,10 +5,12 @@
 
 from flask import jsonify
 
+import pkg_resources
 from omps import __version__ as version
 from . import API
 
 
 @API.route("/about", methods=('GET',))
 def about():
-    return jsonify(version=version)
+    courier_version = pkg_resources.get_distribution('operator-courier').version
+    return jsonify(version=version, operatorcourier=courier_version)

--- a/tests/api/v1/test_about.py
+++ b/tests/api/v1/test_about.py
@@ -3,6 +3,7 @@
 # see the LICENSE file for license
 #
 
+import pkg_resources
 import requests
 from omps import __version__ as version
 
@@ -14,5 +15,6 @@ def test_about(client):
 
     assert rv.status_code == requests.codes.ok
     assert rv.get_json() == {
-        'version': version
+        'version': version,
+        'operatorcourier': pkg_resources.get_distribution('operator-courier').version,
     }

--- a/tests/api/v2/test_about.py
+++ b/tests/api/v2/test_about.py
@@ -3,6 +3,7 @@
 # see the LICENSE file for license
 #
 
+import pkg_resources
 import requests
 from omps import __version__ as version
 
@@ -14,5 +15,6 @@ def test_about(client):
 
     assert rv.status_code == requests.codes.ok
     assert rv.get_json() == {
-        'version': version
+        'version': version,
+        'operatorcourier': pkg_resources.get_distribution('operator-courier').version,
     }


### PR DESCRIPTION
Add an 'operatorcourier' field to the response given by '/about' which
tells the current version of that component.

Resolves #55.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>