### PR TITLE
Ask for kerberos devel package to be installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,10 +135,12 @@ pip install '.[test]'
 
 Project is integrated with tox:
 
-* please install `rpm-devel` (Fedora) or `rpm` (Ubuntu) package to be able
-build `koji` dependency `rpm-py-installer` in `tox`:
+* please install `rpm-devel` and `krb5-devel`  (Fedora) or `rpm` and
+  `libkrb5-dev` (Ubuntu) package to be able build `koji` dependency
+  `rpm-py-installer` in `tox`:
+
 ```bash
-sudo dnf install -y rpm-devel
+sudo dnf install -y rpm-devel krb5-devel
 ```
 * run:
 ```bash


### PR DESCRIPTION
Kerberos headers have to be installed in order to be able to build
rpm-py-installer, a dependency of Koji.

Make the above clear in README.md .

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>