### PR TITLE
Replacing registries

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,16 @@ class ProdConfig:
     REQUEST_TIMEOUT = 28
 
     # Organization access
-    organizations = {
+    ORGANIZATIONS = {
         "public-org": {
             "public": True,
             "oauth_token" "application_access_token_goes_here"
+            "replace_registry": [
+                {
+                    "old": "quay.io",
+                    "new": "example.com",
+                },
+            ]
         }
     }
 
@@ -64,6 +70,23 @@ Organizations configuration options:
 * `public`: if `True` OMPS publish all new repositories in that organization
  (requires `oauth_token`). Default is `False` repositories are private.
 * `oauth_token`: application oauth access token from quay.io
+
+#### Replacing registries URLs in manifest files
+
+If organization have configured `replace_registry` section in the particular
+organization:
+```
+"replace_registry": [
+    {
+        "old": "quay.io",
+        "new": "example.com",
+    },
+]
+```
+all specified `old` registries will be replaced by `new` in all manifests yaml
+files for that organization. Replacement happen during pushing manifests into
+application registry.
+
 
 ### Greenwave integration
 

--- a/docs/usage/v1.md
+++ b/docs/usage/v1.md
@@ -18,6 +18,8 @@ If `<version>` is omitted:
 
 `<version>` must be unique for repository. Quay doesn't support overwriting of releases.
 
+**Note**: if configured, registry URLs will be replaced during push.
+
 #### Replies
 
 **OK**
@@ -98,6 +100,9 @@ If `<version>` is omitted:
 * for new repository a default initial version will be used (`DEFAULT_RELEASE_VERSION` config option)
 
 `<version>` must be unique for repository. Quay doesn't support overwriting of releases.
+
+**Note**: if configured, registry URLs will be replaced during push.
+
 
 #### Replies
 

--- a/docs/usage/v2.md
+++ b/docs/usage/v2.md
@@ -21,6 +21,9 @@ If `<version>` is omitted:
 Target `repository` name is taken from the `packageName` attribute specified in the uploaded operator manifest.
 
 
+**Note**: if configured, registry URLs will be replaced during push.
+
+
 #### Replies
 
 **OK**
@@ -103,6 +106,9 @@ If `<version>` is omitted:
 `<version>` must be unique for repository. Quay doesn't support overwriting of releases.
 
 Target `repository` name is taken from the `packageName` attribute specified in the uploaded operator manifest.
+
+**Note**: if configured, registry URLs will be replaced during push.
+
 
 #### Replies
 

--- a/omps/api/v1/push.py
+++ b/omps/api/v1/push.py
@@ -15,7 +15,7 @@ from operatorcourier.api import flatten
 from operatorcourier.errors import OpCourierError
 
 from . import API
-from omps.api.common import extract_auth_token
+from omps.api.common import extract_auth_token, replace_registries
 from omps.constants import (
     ALLOWED_EXTENSIONS,
     DEFAULT_ZIPFILE_MAX_UNCOMPRESSED_SIZE,
@@ -233,6 +233,8 @@ def _zip_flow(*, organization, repo, version, extract_manifest_func,
 
             version = get_package_version(quay_org, repo, version)
             logger.info("Using release version: %s", version)
+
+            replace_registries(quay_org, tmpdir_flatten)
 
             quay_org.push_operator_manifest(repo, version, tmpdir_flatten)
 

--- a/tests/api/test_common.py
+++ b/tests/api/test_common.py
@@ -1,0 +1,41 @@
+#
+# Copyright (C) 2019 Red Hat, Inc
+# see the LICENSE file for license
+#
+
+import os
+
+from omps.api.common import replace_registries
+from omps.quay import QuayOrganization
+
+
+def test_replace_registries(datadir):
+    """Test if registry is replaced in all files"""
+    def _yield_yaml_files(dir_path):
+        for root, _, files in os.walk(dir_path):
+            for fname in files:
+                fname_lower = fname.lower()
+                if fname_lower.endswith('.yml') or fname_lower.endswith('.yaml'):
+                    yield os.path.join(root, fname)
+
+    dir_path = os.path.join(datadir, 'etcd_op_nested')
+    old = 'quay.io'
+    new = 'example.com'
+    qo = QuayOrganization('testorg', 'random token', replace_registry_conf=[
+        {'old': old, 'new': new}
+    ])
+
+    should_be_replaced = set()
+    for fpath in _yield_yaml_files(dir_path):
+        with open(fpath, 'r') as f:
+            text = f.read()
+            if old in text:
+                should_be_replaced.add(fpath)
+
+    replace_registries(qo, dir_path)
+
+    for fpath in should_be_replaced:
+        with open(fpath, 'r') as f:
+            text = f.read()
+            assert new in text
+            assert old not in text

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -114,6 +114,12 @@ def test_organizations():
         'myorg': {
             'public': False,
             'oauth_token': 'token',
+            'replace_registry': [
+                {
+                    'old': 'quay.io',
+                    'new': 'example.com',
+                },
+            ]
         }
     }
 
@@ -138,6 +144,22 @@ def test_organizations():
     }, {
         'organization': {
             'oauth_token': 10
+        }
+    }, {
+        'organization': {
+            'replace_registry': {}
+        }
+    }, {
+        'organization': {
+            'replace_registry': [
+                {'new': 'expected old too'}
+            ]
+        }
+    }, {
+        'organization': {
+            'replace_registry': [
+                {'old': 'expected new too'}
+            ]
         }
     }
 


### PR DESCRIPTION
Adding configuration options per organization for replacing registry.

This feature allows to force manifests using required registry per
organization. Current implementation do only substring replacements.

* OSBS-6984

Signed-off-by: Martin Bašti <mbasti@redhat.com>