### PR TITLE
Test against multiple versions of operator-courier.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,19 @@ matrix:
   include:
     - dist: trusty
       python: "3.6"
-      env: TOXENV=py36
+      env: TOXENV=py36-courier_released
       after_success: coveralls
     - dist: xenial
       python: "3.7"
-      env: TOXENV=py37
+      env: TOXENV=py37-courier_released
+      after_success: coveralls
+    - dist: trusty
+      python: "3.6"
+      env: TOXENV=py36-courier_master
+      after_success: coveralls
+    - dist: xenial
+      python: "3.7"
+      env: TOXENV=py37-courier_master
       after_success: coveralls
     - dist: xenial
       python: "3.7"

--- a/README.md
+++ b/README.md
@@ -188,7 +188,12 @@ sudo dnf install -y rpm-devel krb5-devel
 tox
 ```
 
+Additionally, you can run the following to execute tests against the
+latest *unreleased* version of Operator Courier:
 
+```bash
+tox -e 'py{36,37}-courier_master'
+```
 
 To run tests manually, you can use pytest directly:
 ```bash

--- a/omps/manifests_util.py
+++ b/omps/manifests_util.py
@@ -49,6 +49,11 @@ class ManifestBundle:
     def package_name(self):
         """Returns defined package name from operator bundle"""
         #  op. courier do verification, this should be never empty
-        pkgs_yaml = self.bundle['data']['packages']
+        if hasattr(self.bundle, 'bundle'):
+            # New, op. courier >= 2.0.0
+            pkgs_yaml = self.bundle.bundle['data']['packages']
+        else:
+            # Old, op. courier < 2.0.0
+            pkgs_yaml = self.bundle['data']['packages']
         pkgs = yaml.safe_load(io.StringIO(pkgs_yaml))
         return pkgs[0]['packageName']

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,11 @@
 [tox]
-envlist = py36,py37,flake8
+envlist = py{36,37}-courier_{released,master},flake8
 
 [testenv]
-deps = .[test]
+deps =
+    courier_master: -e git://github.com/operator-framework/operator-courier#egg=operatorcourier
+    courier_released: operator-courier
+    .[test]
 commands = pytest --cov=omps --ignore=tests/integration tests/
 
 [coverage:report]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{36,37}-courier_{released,master},flake8
+envlist = py{36,37}-courier_released,flake8
 
 [testenv]
 deps =


### PR DESCRIPTION
This will let us test against the currently released version of operator
courier on pypi, as well as whatever they have cooking in their master branch.

An upcoming release (2.0.0) is going to have a small break in backwards
compatibility, handled here.