### PR TITLE
Swap downloading from Koji and checking Greenwave

### DIFF
--- a/omps/api/v1/push.py
+++ b/omps/api/v1/push.py
@@ -134,9 +134,9 @@ def extract_zip_file_from_koji(
         after uncompressing
     """
     with NamedTemporaryFile('wb', suffix='.zip') as tmpf:
+        KOJI.download_manifest_archive(nvr, tmpf)
         if GREENWAVE.enabled:
             GREENWAVE.check_build(nvr)
-        KOJI.download_manifest_archive(nvr, tmpf)
         _extract_zip_file(tmpf.name, target_dir,
                           max_uncompressed_size=max_uncompressed_size)
 


### PR DESCRIPTION
In order to have consistent errors when an NVR cannot be found, download
the manifest from Koji first, and then check Greenwave if policies are
satisfied.

This way a missing NVR will not produce a different error when Greenwave
is not enabled.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>