### PR TITLE
Update expectation when archive for NVR is invalid

### DIFF
--- a/tests/integration/push_nvr/push_nvr_test.py
+++ b/tests/integration/push_nvr/push_nvr_test.py
@@ -20,9 +20,9 @@ def test_invalid_zip(omps):
     response = omps.fetch_nvr(organization=test_env['test_namespace'],
                               repo=test_env['test_package'], nvr=nvr)
 
-    assert response.status_code == requests.codes.bad_request
-    assert response.json()['error'] == 'PackageValidationError'
-    assert 'bundle is invalid' in response.json()['message']
+    assert response.status_code == requests.codes.server_error
+    assert response.json()['error'] == 'QuayCourierError'
+    assert 'Failed to flatten manifest directory' in response.json()['message']
 
 
 def test_not_an_operator(omps):


### PR DESCRIPTION
With operator-courier 2.0.3, the error when an archive for an NVR does
not contain a valid manifest changed. Update integration test
expectations accordingly.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>