### PR TITLE
Only log this statement when replacement will really happen.

### DIFF
--- a/omps/quay.py
+++ b/omps/quay.py
@@ -259,8 +259,9 @@ class QuayOrganization:
         for conf in self._replace_registry_conf:
             old = conf['old']
             new = conf['new']
-            self.logger.info("Replacing registry '%s' with '%s'", old, new)
-            text = text.replace(old, new)
+            if old in text:
+                self.logger.info("Replacing registry '%s' with '%s'", old, new)
+                text = text.replace(old, new)
 
         return text
 


### PR DESCRIPTION
Otherwise, our logs are full of lines indicating that something is being
replaced, with little indication of what is really happening.