### PR TITLE
Log OMPS errors

### DIFF
--- a/omps/errors.py
+++ b/omps/errors.py
@@ -206,7 +206,12 @@ def init_errors_handling(app):
     @app.errorhandler(OMPSError)
     def omps_errors(e):
         """Handle OMPS application errors"""
-        response = jsonify(e.to_dict())
+        err_dict = e.to_dict()
+        app.logger.error(
+            'OMPS error: %s: %r',
+            err_dict['error'], err_dict
+        )
+        response = jsonify(err_dict)
         response.status_code = e.code
         return response
 


### PR DESCRIPTION
Instead of just passing OMPS errors to client, we should also log what
happened in case that client just dropped content of message.

Signed-off-by: Martin Bašti <mbasti@redhat.com>