### PR TITLE
integration.Dockerfile: image for integration tests

### DIFF
--- a/integration.Dockerfile
+++ b/integration.Dockerfile
@@ -1,0 +1,35 @@
+FROM fedora:29
+LABEL \
+    name="Operators Manifests Push Service" \
+    vendor="Red Hat, Inc" \
+    image="integration" \
+    license="GPLv3"
+
+# Test and build dependencies.
+RUN dnf -y install \
+    git \
+    gcc \
+    redhat-rpm-config \
+    popt-devel \
+    rpm-devel \
+    krb5-devel \
+    python3-devel \
+    python3-gunicorn \
+    python3-flask \
+    python3-jsonschema \
+    python3-koji \
+    python3-pyyaml \
+    python3-requests \
+    python3-operator-courier \
+    && dnf -y clean all \
+    && rm -rf /tmp/*
+
+RUN dnf --enablerepo=updates-testing -y update python3-operator-courier \
+    && dnf -y clean all \
+    && rm -rf /tmp/*
+
+RUN pip3 install tox coveralls
+
+WORKDIR /src
+COPY . .
+RUN pip3 install -e .


### PR DESCRIPTION
Image containing all runtime and integration test dependencies. This should be built on each commit to master and pushed remotely, and ideally on every release. The idea is to use this as a base image for operator-courier's as well as OMPS' integration tests.

/cc @csomh @MartinBasti @shawn-hurley @gallettilance