### PR TITLE
tests/integration: fix cleanup steps

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -24,8 +24,6 @@ def quay():
 
     yield app_registry
 
-    app_registry.delete(test_env['test_namespace'], test_env['test_package'])
-
 
 @pytest.fixture(scope='session')
 def omps(quay):

--- a/tests/integration/push_archive/push_archive_test.py
+++ b/tests/integration/push_archive/push_archive_test.py
@@ -48,7 +48,8 @@ def test_nested_manifest(omps, quay, tmp_path):
     then pushing the data is successful.
     """
     version = '1.0.0'
-    quay.delete(test_env['test_namespace'], test_env['test_package'])
+    # Clean up application repository before running.
+    omps.delete(test_env['test_namespace'], test_env['test_package'])
     archive = shutil.make_archive(tmp_path / 'archive', 'zip',
                                   'tests/integration/artifacts/nested/')
 


### PR DESCRIPTION
Both removed steps attempt to delete a quay.io application repository, which will not work with typical account permissions. Deleting all application releases before a test runs should suffice.

/cc @csomh @MartinBasti 