### PR TITLE
Add Regex support to OMPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,10 +83,23 @@ organization:
     },
 ]
 ```
-all specified `old` registries will be replaced by `new` in all manifests yaml
-files for that organization. Replacement happen during pushing manifests into
-application registry.
+All specified `old` registries will be replaced by `new` in all manifests yaml
+files for that organization.
 
+You can pattern match and replace registry strings with the regexp field instead
+of matching whole strings.  Both `old` and `new` will be evalutated as regexes
+when `regexp` is set to `True`.  If `regexp` is missing it defaults to `False`.
+Here's an example:
+```
+"replace_registry": [
+    {
+        "old": "quay.io$",
+        "new": "example.com",
+        "regexp": True,
+    },
+]
+```
+Replacements occur when pushing manifests into the application registry.
 
 ### Greenwave integration
 

--- a/example.test.env.yaml
+++ b/example.test.env.yaml
@@ -42,6 +42,7 @@ private_org:
 replace_registry:
   - old: registry.stage.redhat.io
     new: registry.redhat.io
+    regexp: false
 # Config of the instance tested to check if Greenwave policies are met for the
 # NVR
 greenwave:

--- a/omps/quay.py
+++ b/omps/quay.py
@@ -257,9 +257,15 @@ class QuayOrganization:
             return text
 
         for conf in self._replace_registry_conf:
-            old = conf['old']
             new = conf['new']
-            if old in text:
+            old = conf['old']
+            regexp = conf.get('regexp', False)
+
+            if regexp:
+                if re.search(old, text, flags=re.MULTILINE):
+                    self.logger.info("Replacing registries with regexp '%s'", regexp)
+                    text = re.sub(old, new, text, flags=re.MULTILINE)
+            elif old in text:
                 self.logger.info("Replacing registry '%s' with '%s'", old, new)
                 text = text.replace(old, new)
 

--- a/tests/api/test_common.py
+++ b/tests/api/test_common.py
@@ -22,7 +22,7 @@ def test_replace_registries(datadir):
     old = 'quay.io'
     new = 'example.com'
     qo = QuayOrganization('testorg', 'random token', replace_registry_conf=[
-        {'old': old, 'new': new}
+        {'old': old, 'new': new, 'regexp': False}
     ])
 
     should_be_replaced = set()

--- a/tests/integration/replace_registry/replace_registry_test.py
+++ b/tests/integration/replace_registry/replace_registry_test.py
@@ -41,7 +41,7 @@ def test_replace_during_nvr_push(omps, quay, koji, tmp_path):
         the manifest at 'path'
 
         Args:
-            replace_conf: List of {'old': ..., 'new': ...} dictionaries.
+            replace_conf: List of {'old': ..., 'new': ..., 'regexp': ...} dictionaries.
             path: Path of the manifest.
 
         Returns:

--- a/tests/test_quay.py
+++ b/tests/test_quay.py
@@ -483,6 +483,19 @@ class TestQuayOrganization:
         assert res == text
         assert id(res) == id(text)
 
+    @pytest.mark.parametrize('text,expected', [
+        (
+            'Registry reg_old will be replaced using a regexp: reg_old',
+            'Registry reg_old will be replaced using a regexp: reg_new',
+        )
+    ])
+    def test_regexp_replace_registries(self, text, expected):
+        """Test if registries are replaced properly with regexp"""
+        replace_conf = [{'old': 'reg_old$', 'new': 'reg_new', 'regexp': True}]
+        org = 'testorg'
+        qo = QuayOrganization(org, TOKEN, replace_registry_conf=replace_conf)
+        assert qo.replace_registries(text) == expected
+
 
 class TestOrgManager:
     """Tets for OrgManager class"""

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -130,6 +130,29 @@ def test_organizations():
     assert conf.organizations == expected
 
 
+def test_organziation_regexp():
+    """Organziation with regexp Test"""
+    expected = {
+        'myorg': {
+            'public': False,
+            'oauth_token': 'token',
+            'replace_registry': [
+                {
+                    'old': 'quay.io/$',
+                    'new': 'example.com',
+                    'regexp': True,
+                },
+            ]
+        }
+    }
+
+    class ConfClass(DefaultConfig):
+        ORGANIZATIONS = expected
+
+    conf = Config(ConfClass)
+    assert conf.organizations == expected
+
+
 @pytest.mark.parametrize('conf', [
     {
         'organization': None
@@ -159,6 +182,12 @@ def test_organizations():
         'organization': {
             'replace_registry': [
                 {'old': 'expected new too'}
+            ]
+        }
+    }, {
+        'organization': {
+            'replace_registry': [
+                {'regexp': False}
             ]
         }
     }


### PR DESCRIPTION
The current pattern for registry string replacement only matches on whole
strings.  This pattern is very broad and lacks the precision to handle corner
cases like strings that only end or begin with '/'.  Regexes provide the
precision needed to expand pattern matching to handle more precise string replacement.