### PR TITLE
Use different endpoint to get releases

### DIFF
--- a/tests/api/v2/conftest.py
+++ b/tests/api/v2/conftest.py
@@ -15,9 +15,8 @@ EntrypointMeta = namedtuple('EntrypointMeta', 'url_path,org,repo,version,nvr')
     True,  # endpoint with version
     False,  # endpoint without version
 ])
-def endpoint_push_zipfile(request, release_version):
+def endpoint_push_zipfile(request, release_version, organization):
     """Returns URL for zipfile endpoints"""
-    organization = 'testorg'
     version = release_version if request.param else None
 
     url_path = '/v2/{}/zipfile'.format(organization)
@@ -34,9 +33,8 @@ def endpoint_push_zipfile(request, release_version):
     True,  # endpoint with version
     False,  # endpoint without version
 ])
-def endpoint_push_koji(request, release_version):
+def endpoint_push_koji(request, release_version, organization):
     """Returns URL for koji endpoints"""
-    organization = 'testorg'
     nvr = 'build-1.0.1-2'
     version = release_version if request.param else None
 
@@ -54,9 +52,8 @@ def endpoint_push_koji(request, release_version):
     True,  # endpoint with version
     False,  # endpoint without version
 ])
-def endpoint_packages(request, release_version):
+def endpoint_packages(request, release_version, organization):
     """Returns URL for packages endpoints"""
-    organization = 'testorg'
     repo = 'repo-Y'
 
     url_path = '/v2/{}/{}'.format(organization, repo)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,6 +29,11 @@ ManifestDirMeta = namedtuple('ManifestDirMeta', ['path', 'pkg_name', 'valid'])
 
 
 @pytest.fixture()
+def organization():
+    return 'testorg'
+
+
+@pytest.fixture()
 def release_version():
     return "0.0.1"
 
@@ -146,20 +151,23 @@ def mocked_quay_io():
     """Mocking quay.io answers"""
     with requests_mock.Mocker() as m:
         m.get(
-            re.compile(r'/cnr/api/v1/packages/.*'),
-            status_code=404,
+            re.compile(r'/cnr/api/v1/packages\?.*'),
+            json=[]
         )
         yield m
 
 
 @pytest.fixture
-def mocked_packages_delete_quay_io(release_version):
+def mocked_packages_delete_quay_io(release_version, organization):
     """Mocking quay.io answers for retrieving and deleting packages"""
     with requests_mock.Mocker() as m:
         m.get(
-            re.compile(r'/cnr/api/v1/packages/.*'),
+            re.compile(r'/cnr/api/v1/packages\?.*'),
             json=[
-                {"release": release_version},
+                {
+                    "releases": [release_version],
+                    "name": f'{organization}/repo-Y'
+                },
             ],
         )
         m.delete(


### PR DESCRIPTION
Endpoint /cnr/api/v1/packages?namespace=<org> provides information about
releases and is more efficient than listing all releases.

* OSBS-8334

Signed-off-by: Martin Bašti <mbasti@redhat.com>