### PR TITLE
Tests: adjust some assertions

### DIFF
--- a/tests/integration/delete_version/delete_version_test.py
+++ b/tests/integration/delete_version/delete_version_test.py
@@ -92,11 +92,9 @@ def test_delete_all_versions(omps, quay, tmp_path):
     response = omps.delete(test_env['test_namespace'], test_env['test_package'])
 
     assert response.status_code == requests.codes.ok
-    assert response.json() == {
-        'deleted': versions,
-        'organization': test_env['test_namespace'],
-        'repo': test_env['test_package'],
-    }
+    assert sorted(response.json()["deleted"]) == sorted(versions)
+    assert response.json()["organization"] == test_env["test_namespace"]
+    assert response.json()["repo"] == test_env["test_package"]
 
     assert not quay.get_releases(test_env['test_namespace'],
                                  test_env['test_package'],

--- a/tests/integration/push_archive/push_archive_test.py
+++ b/tests/integration/push_archive/push_archive_test.py
@@ -245,7 +245,7 @@ def test_organization_unaccessible_in_quay(omps, tmp_path):
 
     assert response.status_code == requests.codes.forbidden
     assert response.json()['error'] == 'QuayAuthorizationError'
-    assert 'Cannot retrieve information about package' in response.json()['message']
+    assert "Unauthorized access" in response.json()['message']
 
 
 def test_upload_password_protected_zip(omps):

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,6 @@ deps =
     PyYAML
     operator-courier >= 1.3.0
     koji
-passenv = OMPS_INT_TEST_*
 setenv =
     REQUESTS_CA_BUNDLE = /etc/pki/tls/certs/ca-bundle.crt
 commands =


### PR DESCRIPTION
With #97 the message when reaching out to a quay org not accessible
changed: adjust the test expectation accordingly.

When deleting all versions, the way versions are sorted in the deleted
list changed: make sure both the actual and expected lists are sorted to
avoid tests failing for this reason in the future.

Remove an unused environment variable from the tox config.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>