### PR TITLE
Improve documentation of the integration test config

### DIFF
--- a/example.test.env.yaml
+++ b/example.test.env.yaml
@@ -5,11 +5,12 @@
 quay_app_registry_api: https://quay.io/cnr/api/v1
 # URL of the Quay API. No trailing '/'.
 quay_api: https://quay.io/api/v1
-# OAuth token to be used for request going to quay_api
+# OAuth aplication token with repository read/write access in the
+# *test_namespace* to be used for requests going to quay_api.
 quay_oauth_token: <quay application token>
-# User to authenticate with Quay.
+# Robot account in the *test_namespace* with *Creator* team role.
 quay_user: <robot account>
-# Password to authenticate with Quay.
+# Token for the robot account in the *test_namespace*.
 quay_password: <robot token>
 # URL of the OMPS API. No trailing '/'.
 # Includes version, tests adjust to the version.
@@ -34,7 +35,9 @@ koji_builds:
 # Configuration to test that an organization not configured
 # to be made public is kept private.
 private_org:
+  # Robot account in *namespace* with *Creator* team role.
   user: <robot account>
+  # Token for the robot account in the *namespace*.
   password: <robot token>
   namespace: private-operators
   package: integration-tests-private
@@ -47,8 +50,9 @@ replace_registry:
 alter_package_name:
   # namespace in which package names should be altered
   namespace: integration-tests
-  # robot account credentials with access to the namespace
+  # Robot account in *namespace* with *Creator* team role.
   user: <robot account>
+  # Token for the robot account in the *namespace*.
   password: <robot token>
   # suffix used to alter package names
   suffix: "-test-suffix"


### PR DESCRIPTION
Document where the different robot accounts and tokens should come from
and what credentials should they have.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>