### PR TITLE
Fix v2 API examples

### DIFF
--- a/docs/usage/v2.md
+++ b/docs/usage/v2.md
@@ -74,14 +74,14 @@ For the following errors, the response will contain extra fields:
 ```bash
 curl \
   -H "Authorization: ${TOKEN}" \
-  -X POST https://example.com/v2/myorg/myrepo/zipfile \
+  -X POST https://example.com/v2/myorg/zipfile \
   -F "file=@manifests.zip"
 ```
 or with explicit release version
 ```bash
 curl \
   -H "Authorization: ${TOKEN}" \
-  -X POST https://example.com/v2/myorg/myrepo/zipfile/1.1.5 \
+  -X POST https://example.com/v2/myorg/zipfile/1.1.5 \
   -F "file=@manifests.zip"
 ```
 
@@ -168,13 +168,13 @@ For the following errors, the response will contain extra fields:
 ```bash
 curl \
   -H "Authorization: ${TOKEN}" \
-  -X POST https://example.com/v2/myorg/myrepo/koji/image-1.2-5
+  -X POST https://example.com/v2/myorg/koji/image-1.2-5
 ```
 or with explicit release version
 ```bash
 curl \
   -H "Authorization: ${TOKEN}" \
-  -X POST https://example.com/v2/myorg/myrepo/koji/image-1.2-5/1.1.5
+  -X POST https://example.com/v2/myorg/koji/image-1.2-5/1.1.5
 ```
 
 


### PR DESCRIPTION
repository is not in V2 api path

Signed-off-by: Martin Bašti <mbasti@redhat.com>