### PR TITLE
Remove rpm operator-courier dependency and install it from pypi instead

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ RUN dnf -y install \
     python3-requests \
     python3-ruamel-yaml \
     python3-pip \
+    python3-pyyaml \
     && dnf -y clean all \
     && rm -rf /tmp/*
 
@@ -32,7 +33,7 @@ RUN if [ "$cacert_url" != "undefined" ]; then \
 # This will allow a non-root user to install a custom root CA at run-time
 RUN chmod 777 /etc/pki/tls/certs/ca-bundle.crt
 COPY . .
-RUN pip3 install -r requirements-operator-courier.txt
+RUN pip3 install --require-hashes --no-deps -r requirements-operator-courier.txt
 RUN pip3 install . --no-deps
 USER 1001
 EXPOSE 8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,13 +19,8 @@ RUN dnf -y install \
     python3-jsonschema \
     python3-koji \
     python3-requests \
-    python3-operator-courier \
     python3-ruamel-yaml \
     python3-pip \
-    && dnf -y clean all \
-    && rm -rf /tmp/*
-
-RUN dnf --enablerepo=updates-testing -y update python3-operator-courier \
     && dnf -y clean all \
     && rm -rf /tmp/*
 
@@ -37,6 +32,7 @@ RUN if [ "$cacert_url" != "undefined" ]; then \
 # This will allow a non-root user to install a custom root CA at run-time
 RUN chmod 777 /etc/pki/tls/certs/ca-bundle.crt
 COPY . .
+RUN pip3 install -r requirements-operator-courier.txt
 RUN pip3 install . --no-deps
 USER 1001
 EXPOSE 8080

--- a/requirements-operator-courier.txt
+++ b/requirements-operator-courier.txt
@@ -1,3 +1,1 @@
 operator-courier == 2.1.8 --hash=sha256:b5482baeff662c1bcba5ec0a97e2f21132ee7a155580ab0ac3b886e1affd8396
-validators == 0.17.1 --hash=sha256:898b6b8197fbc320daf25d3b32fa928fd25e225c33790cb58ed54b48aebe1858
-semver==2.10.2  --hash=sha256:21e80ca738975ed513cba859db0a0d2faca2380aef1962f48272ebf9a8a44bd4

--- a/requirements-operator-courier.txt
+++ b/requirements-operator-courier.txt
@@ -1,4 +1,3 @@
 operator-courier == 2.1.8 --hash=sha256:b5482baeff662c1bcba5ec0a97e2f21132ee7a155580ab0ac3b886e1affd8396
-PyYAML == 5.3.1 --hash=sha256:b8eac752c5e14d3eca0e6dd9199cd627518cb5ec06add0de9d32baeee6fe645d
 validators == 0.17.1 --hash=sha256:898b6b8197fbc320daf25d3b32fa928fd25e225c33790cb58ed54b48aebe1858
 semver==2.10.2  --hash=sha256:21e80ca738975ed513cba859db0a0d2faca2380aef1962f48272ebf9a8a44bd4

--- a/requirements-operator-courier.txt
+++ b/requirements-operator-courier.txt
@@ -1,0 +1,4 @@
+operator-courier == 2.1.8 --hash=sha256:b5482baeff662c1bcba5ec0a97e2f21132ee7a155580ab0ac3b886e1affd8396
+PyYAML == 5.3.1 --hash=sha256:b8eac752c5e14d3eca0e6dd9199cd627518cb5ec06add0de9d32baeee6fe645d
+validators == 0.17.1 --hash=sha256:898b6b8197fbc320daf25d3b32fa928fd25e225c33790cb58ed54b48aebe1858
+semver==2.10.2  --hash=sha256:21e80ca738975ed513cba859db0a0d2faca2380aef1962f48272ebf9a8a44bd4


### PR DESCRIPTION
When there is a new version of courier, the OCP Group F team has to
release it to PyPI, and then we pull it down and build a fedora rawhide
rpm out of it, and then we build a fedora 30+ rpm out of it and create
a bodhi update for that. Then, we wait ~24 hours for it to land in the
testing repo, so that we can build our container image and start
testing OMPS with the new version. This is a silly delay.